### PR TITLE
Require _+_ be cancellative with respect to _≡_ instead of _≤_

### DIFF
--- a/src/Calf/CostMonoid.agda
+++ b/src/Calf/CostMonoid.agda
@@ -18,21 +18,18 @@ module _ {ℂ : Set} where
   _≈_ = _≡_
 
   open import Algebra.Definitions _≈_
-    hiding (LeftCancellative; RightCancellative; Cancellative)
-  open import Algebra.Definitions
-    using (LeftCancellative; RightCancellative; Cancellative)
   open import Algebra.Structures _≈_ public
   open import Relation.Binary.Structures _≈_
 
-  record IsCancellative (_∙_ : Op₂ ℂ) (_≤_ : Relation) : Set where
+  record IsCancellative (_∙_ : Op₂ ℂ) : Set where
     field
-      ∙-cancel-≤ : Cancellative _≤_ _∙_
+      ∙-cancel-≡ : Cancellative _∙_
 
-    ∙-cancelˡ-≤ : LeftCancellative _≤_ _∙_
-    ∙-cancelˡ-≤ = proj₁ ∙-cancel-≤
+    ∙-cancelˡ-≡ : LeftCancellative _∙_
+    ∙-cancelˡ-≡ = proj₁ ∙-cancel-≡
 
-    ∙-cancelʳ-≤ : RightCancellative _≤_ _∙_
-    ∙-cancelʳ-≤ = proj₂ ∙-cancel-≤
+    ∙-cancelʳ-≡ : RightCancellative _∙_
+    ∙-cancelʳ-≡ = proj₂ ∙-cancel-≡
 
   record IsMonotone (_∙_ : Op₂ ℂ) (_≤_ : Relation) (isPreorder : IsPreorder _≤_) : Set where
     field
@@ -51,8 +48,8 @@ module _ {ℂ : Set} where
   record IsCostMonoid (_+_ : Op₂ ℂ) (zero : ℂ) (_≤_ : Relation) : Set where
     field
       isMonoid       : IsMonoid _+_ zero
+      isCancellative : IsCancellative _+_
       isPreorder     : IsPreorder _≤_
-      isCancellative : IsCancellative _+_ _≤_
       isMonotone     : IsMonotone _+_ _≤_ isPreorder
 
     open IsMonoid isMonoid public
@@ -63,16 +60,16 @@ module _ {ℂ : Set} where
         assoc to +-assoc
       )
 
+    open IsCancellative isCancellative public
+      renaming (
+        ∙-cancel-≡ to +-cancel-≡;
+        ∙-cancelˡ-≡ to +-cancelˡ-≡;
+        ∙-cancelʳ-≡ to +-cancelʳ-≡
+      )
+
     open IsPreorder isPreorder public
       using ()
       renaming (refl to ≤-refl; trans to ≤-trans)
-
-    open IsCancellative isCancellative public
-      renaming (
-        ∙-cancel-≤ to +-cancel-≤;
-        ∙-cancelˡ-≤ to +-cancelˡ-≤;
-        ∙-cancelʳ-≤ to +-cancelʳ-≤
-      )
 
     open IsMonotone isMonotone public
       renaming (
@@ -85,8 +82,8 @@ module _ {ℂ : Set} where
     field
       isMonoid            : IsMonoid _⊕_ 𝟘
       isCommutativeMonoid : IsCommutativeMonoid _⊗_ 𝟙
+      isCancellative      : IsCancellative _⊕_
       isPreorder          : IsPreorder _≤_
-      isCancellative      : IsCancellative _⊕_ _≤_
       isMonotone-⊕        : IsMonotone _⊕_ _≤_ isPreorder
       isMonotone-⊗        : IsMonotone _⊗_ _≤_ isPreorder
 
@@ -107,16 +104,16 @@ module _ {ℂ : Set} where
         comm to ⊗-comm
       )
 
+    open IsCancellative isCancellative public
+      renaming (
+        ∙-cancel-≡ to ⊕-cancel-≡;
+        ∙-cancelˡ-≡ to ⊕-cancelˡ-≡;
+        ∙-cancelʳ-≡ to ⊕-cancelʳ-≡
+      )
+
     open IsPreorder isPreorder public
       using ()
       renaming (refl to ≤-refl; trans to ≤-trans)
-
-    open IsCancellative isCancellative public
-      renaming (
-        ∙-cancel-≤ to ⊕-cancel-≤;
-        ∙-cancelˡ-≤ to ⊕-cancelˡ-≤;
-        ∙-cancelʳ-≤ to ⊕-cancelʳ-≤
-      )
 
     open IsMonotone isMonotone-⊕ public
       renaming (
@@ -147,7 +144,7 @@ record CostMonoid : Set₁ where
 record ParCostMonoid : Set₁ where
   infixl 7 _⊗_
   infixl 6 _⊕_
-  
+
   field
     ℂ               : Set
     _⊕_             : Op₂ ℂ

--- a/src/Calf/CostMonoids.agda
+++ b/src/Calf/CostMonoids.agda
@@ -16,8 +16,8 @@ open import Relation.Binary.PropositionalEquality
   ; _≤_ = _≤_
   ; isCostMonoid = record
     { isMonoid = +-0-isMonoid
+    ; isCancellative = record { ∙-cancel-≡ = +-cancel-≡ }
     ; isPreorder = ≤-isPreorder
-    ; isCancellative = record { ∙-cancel-≤ = +-cancel-≤ }
     ; isMonotone = record { ∙-mono-≤ = +-mono-≤ }
     }
   }
@@ -36,8 +36,8 @@ open import Relation.Binary.PropositionalEquality
   ; isParCostMonoid = record
     { isMonoid = +-0-isMonoid
     ; isCommutativeMonoid = +-0-isCommutativeMonoid
+    ; isCancellative = record { ∙-cancel-≡ = +-cancel-≡ }
     ; isPreorder = ≤-isPreorder
-    ; isCancellative = record { ∙-cancel-≤ = +-cancel-≤ }
     ; isMonotone-⊕ = record { ∙-mono-≤ = +-mono-≤ }
     ; isMonotone-⊗ = record { ∙-mono-≤ = +-mono-≤ }
     }
@@ -58,7 +58,7 @@ open import Relation.Binary.PropositionalEquality
     { isMonoid = +-0-isMonoid
     ; isCommutativeMonoid = ⊔-0-isCommutativeMonoid
     ; isPreorder = ≤-isPreorder
-    ; isCancellative = record { ∙-cancel-≤ = +-cancel-≤ }
+    ; isCancellative = record { ∙-cancel-≡ = +-cancel-≡ }
     ; isMonotone-⊕ = record { ∙-mono-≤ = +-mono-≤ }
     ; isMonotone-⊗ = record { ∙-mono-≤ = ⊔-mono-≤ }
     }
@@ -109,15 +109,15 @@ combineParCostMonoids pcm₁ pcm₂ = record
         }
       ; comm = λ (a₁ , a₂) (b₁ , b₂) → cong₂ _,_ (⊗-comm pcm₁ a₁ b₁) (⊗-comm pcm₂ a₂ b₂)
       }
+    ; isCancellative = record
+      { ∙-cancel-≡ =
+        (λ (x₁ , x₂)           h → cong₂ _,_ (⊕-cancelˡ-≡ pcm₁ x₁    (cong proj₁ h)) (⊕-cancelˡ-≡ pcm₂ x₂    (cong proj₂ h))) ,
+        (λ (y₁ , y₂) (z₁ , z₂) h → cong₂ _,_ (⊕-cancelʳ-≡ pcm₁ y₁ z₁ (cong proj₁ h)) (⊕-cancelʳ-≡ pcm₂ y₂ z₂ (cong proj₂ h)))
+      }
     ; isPreorder = record
       { isEquivalence = isEquivalence
       ; reflexive = λ { refl → ≤-refl pcm₁ , ≤-refl pcm₂ }
       ; trans = λ (h₁ , h₂) (h₁' , h₂') → ≤-trans pcm₁ h₁ h₁' , ≤-trans pcm₂ h₂ h₂'
-      }
-    ; isCancellative = record
-      { ∙-cancel-≤ =
-        (λ (x₁ , x₂) (h₁ , h₂) → ⊕-cancelˡ-≤ pcm₁ x₁ h₁ , ⊕-cancelˡ-≤ pcm₂ x₂ h₂) ,
-        (λ (y₁ , y₂) (z₁ , z₂) (h₁ , h₂) → ⊕-cancelʳ-≤ pcm₁ y₁ z₁ h₁ , ⊕-cancelʳ-≤ pcm₂ y₂ z₂ h₂)
       }
     ; isMonotone-⊕ = record
       { ∙-mono-≤ = λ (h₁ , h₂) (h₁' , h₂') → ⊕-mono-≤ pcm₁ h₁ h₁' , ⊕-mono-≤ pcm₂ h₂ h₂'


### PR DESCRIPTION
Conveniently, this "detangles" `_≤_`, which could soon be internal/a parameter to `Upper`, rather than a meta-level assumed primitive.