### PR TITLE
Redo coinductive amortized analysis synthetically

### DIFF
--- a/src/Calf/PhaseDistinction.agda
+++ b/src/Calf/PhaseDistinction.agda
@@ -25,11 +25,11 @@ infix 10 ◯⁺_
 infix 10 ◯⁻_
 postulate
   ext/val : (ext → tp pos) → tp pos
-  ext/val/decode : ∀ {A} → val (ext/val A) ≡ ∀ (u : ext) → (val (A u))
+  ext/val/decode : ∀ {A} → val (ext/val A) ≡ ((u : ext) → val (A u))
   {-# REWRITE ext/val/decode #-}
 
   ext/cmp : (ext → tp neg) → tp neg
-  ext/cmp/decode : ∀ {A} → val (U (ext/cmp A)) ≡ ∀ (u : ext) → (cmp (A u))
+  ext/cmp/decode : ∀ {A} → val (U (ext/cmp A)) ≡ ((u : ext) → cmp (A u))
   {-# REWRITE ext/cmp/decode #-}
 
 ◯⁺_ : tp pos → tp pos
@@ -62,3 +62,26 @@ postulate
     (h : (a : val A) → (u : ext) → P.subst (λ a → cmp (X a)) (η≡∗ a u) (x0 a) ≡ x1 u ) →
     ●/ind (∗ u) X x0 x1 h ≡ x1 u
   {-# REWRITE ●/ind/β₂ #-}
+
+
+record Extension (X : tp neg) (φ : Ω) (spec : (u : φ) → cmp X) : Set where
+  field
+    out : cmp X
+    law : (u : φ) → out ≡ spec u
+open Extension public
+
+witnessed-by : {X : tp neg} {φ : Ω} {out : cmp X} {spec : (u : φ) → cmp X} → ((u : φ) → out ≡ spec u) → Extension X φ spec
+witnessed-by {out = out} h = record { out = out ; law = h }
+
+exactly : {X : tp neg} {φ : Ω} (spec : cmp X) → Extension X φ λ _ → spec
+exactly x = record { out = x ; law = λ u → refl }
+
+postulate
+  extension-≡ : ∀ {X φ spec} {x y : Extension X φ spec} → out x ≡ out y → x ≡ y
+  -- Trivial proof if `law` field is irrelevant. However, this is annoying to
+  -- work with, since it requires that further-up proofs be irrelevant.
+
+postulate
+  [_∣_↪_] : (X : tp neg) → (φ : Ω) → (spec : (u : φ) → cmp X) → tp neg
+  [∣↪]/decode : ∀ {X φ spec} → val (U [ X ∣ φ ↪ spec ]) ≡ Extension X φ spec
+  {-# REWRITE [∣↪]/decode #-}

--- a/src/Calf/PhaseDistinction.agda
+++ b/src/Calf/PhaseDistinction.agda
@@ -73,8 +73,8 @@ open Extension public
 witnessed-by : {X : tp neg} {φ : Ω} {out : cmp X} {spec : (u : φ) → cmp X} → ((u : φ) → out ≡ spec u) → Extension X φ spec
 witnessed-by {out = out} h = record { out = out ; law = h }
 
-exactly : {X : tp neg} {φ : Ω} (spec : cmp X) → Extension X φ λ _ → spec
-exactly x = record { out = x ; law = λ u → refl }
+exactly : {X : tp neg} {φ : Ω} {spec : cmp X} → Extension X φ λ _ → spec
+exactly {spec = spec} = record { out = spec ; law = λ u → refl }
 
 postulate
   extension-≡ : ∀ {X φ spec} {x y : Extension X φ spec} → out x ≡ out y → x ≡ y

--- a/src/Calf/Step.agda
+++ b/src/Calf/Step.agda
@@ -32,6 +32,9 @@ postulate
   Π/step : ∀ {A} {X : val A → tp neg} {f : cmp (Π A X)} {n} → step (Π A X) n f ≡ λ x → step (X x) n (f x)
   {-# REWRITE Π/step #-}
 
+  Σ+-/step : ∀ {A P c e} → step (Σ+- A P) c e ≡ (proj₁ e , step (P (proj₁ e)) c (proj₂ e))
+  {-# REWRITE Σ+-/step #-}
+
   prod⁻/step : {X Y : tp neg} {c : ℂ} {e : cmp (prod⁻ X Y)} →
     step (prod⁻ X Y) c e ≡ (step X c (proj₁ e) , step Y c (proj₂ e))
   {-# REWRITE prod⁻/step  #-}

--- a/src/Calf/Step.agda
+++ b/src/Calf/Step.agda
@@ -12,6 +12,7 @@ open import Calf.Prelude
 open import Calf.Metalanguage
 open import Calf.PhaseDistinction
 open import Relation.Binary.PropositionalEquality
+open import Calf.Types.Product
 
 cost : tp neg
 cost = meta ℂ
@@ -30,6 +31,10 @@ postulate
 
   Π/step : ∀ {A} {X : val A → tp neg} {f : cmp (Π A X)} {n} → step (Π A X) n f ≡ λ x → step (X x) n (f x)
   {-# REWRITE Π/step #-}
+
+  prod⁻/step : {X Y : tp neg} {c : ℂ} {e : cmp (prod⁻ X Y)} →
+    step (prod⁻ X Y) c e ≡ (step X c (proj₁ e) , step Y c (proj₂ e))
+  {-# REWRITE prod⁻/step  #-}
 
   bind/step : ∀ {A} {X} {e f n} → bind {A} X (step (F A) n e) f ≡ step X n (bind {A} X e f)
   dbind/step : ∀ {A} {X : val A → tp neg} {e f n} → dbind {A} X (step (F A) n e) f ≡ step (tbind {A} e X) n (dbind {A} X e f)

--- a/src/Calf/Step.agda
+++ b/src/Calf/Step.agda
@@ -36,9 +36,21 @@ postulate
     step (prod⁻ X Y) c e ≡ (step X c (proj₁ e) , step Y c (proj₂ e))
   {-# REWRITE prod⁻/step  #-}
 
+  ext/cmp/step : {X : ext → tp neg} {c : ℂ} {e : cmp (ext/cmp X)} →
+    step (ext/cmp X) c e ≡ λ u → step (X u) c (e u)
+  {-# REWRITE ext/cmp/step #-}
+
   bind/step : ∀ {A} {X} {e f n} → bind {A} X (step (F A) n e) f ≡ step X n (bind {A} X e f)
   dbind/step : ∀ {A} {X : val A → tp neg} {e f n} → dbind {A} X (step (F A) n e) f ≡ step (tbind {A} e X) n (dbind {A} X e f)
   {-# REWRITE bind/step dbind/step #-}
 
   step/ext : ∀ X → (e : cmp X) → (c : ℂ) → ◯ (step X c e ≡ e)
   -- sadly the above cannot be made an Agda rewrite rule
+
+  extension/step : ∀ {X spec c e} →
+    step [ X ∣ ext ↪ spec ] c e ≡
+    record
+      { out = step X c (out e)
+      ; law = λ u → trans (step/ext X (out e) c u) (law e u)
+      }
+  {-# REWRITE extension/step #-}

--- a/src/Calf/Types/Product.agda
+++ b/src/Calf/Types/Product.agda
@@ -4,22 +4,16 @@ module Calf.Types.Product where
 
 open import Calf.Prelude
 open import Calf.Metalanguage
+open import Relation.Binary.PropositionalEquality using (_≡_)
 
 open import Data.Product using (_×_; _,_; proj₁; proj₂) public
 
-prod⁺ : tp pos → tp pos → tp pos
-prod⁺ A B = U (meta (val A × val B))
+postulate
+  prod⁺ : tp pos → tp pos → tp pos
+  prod⁺/decode : {A B : tp pos} → val (prod⁺ A B) ≡ (val A × val B)
+  {-# REWRITE prod⁺/decode #-}
 
--- Doesn't seem to work?
--- prod⁻ : tp neg → tp neg → tp neg
--- prod⁻ X Y = meta (cmp X × cmp Y)
-
-record Prod⁻ (X Y : tp neg) : Set where
-  constructor _,_
-  field
-    proj₁ : cmp X
-    proj₂ : cmp Y
-open Prod⁻ public
-
-prod⁻ : tp neg → tp neg → tp neg
-prod⁻ X Y = meta (Prod⁻ X Y)
+postulate
+  prod⁻ : tp neg → tp neg → tp neg
+  prod⁻/decode : {X Y : tp neg} → val (U (prod⁻ X Y)) ≡ (cmp X × cmp Y)
+  {-# REWRITE prod⁻/decode #-}

--- a/src/Calf/Types/Product.agda
+++ b/src/Calf/Types/Product.agda
@@ -10,6 +10,7 @@ open import Data.Product using (_×_; _,_; proj₁; proj₂) public
 prod⁺ : tp pos → tp pos → tp pos
 prod⁺ A B = U (meta (val A × val B))
 
+-- Doesn't seem to work?
 -- prod⁻ : tp neg → tp neg → tp neg
 -- prod⁻ X Y = meta (cmp X × cmp Y)
 

--- a/src/Calf/Types/Product.agda
+++ b/src/Calf/Types/Product.agda
@@ -9,3 +9,16 @@ open import Data.Product using (_×_; _,_; proj₁; proj₂) public
 
 prod⁺ : tp pos → tp pos → tp pos
 prod⁺ A B = U (meta (val A × val B))
+
+-- prod⁻ : tp neg → tp neg → tp neg
+-- prod⁻ X Y = meta (cmp X × cmp Y)
+
+record Prod⁻ (X Y : tp neg) : Set where
+  constructor _,_
+  field
+    proj₁ : cmp X
+    proj₂ : cmp Y
+open Prod⁻ public
+
+prod⁻ : tp neg → tp neg → tp neg
+prod⁻ X Y = meta (Prod⁻ X Y)

--- a/src/Examples/Amortized.agda
+++ b/src/Examples/Amortized.agda
@@ -34,9 +34,12 @@ variable
 
 record StepCommutative : Set where
   field
-    bind/bind : {A B : tp pos} {X : tp neg}
-      (e₁ : cmp (F A)) (e₂ : cmp (F B)) (f : val A → val B → cmp X) →
-        (bind X e₁ λ x₁ → bind X e₂ λ x₂ → f x₁ x₂) ≡ (bind X e₂ λ x₂ → bind X e₁ λ x₁ → f x₁ x₂)
+    step/bind : (e : cmp (F A)) (f : val A → cmp X) (c : ℂ) →
+      step X c (bind X e f) ≡
+      bind X e (λ a → step X c (f a))
+    bind/bind : (e₁ : cmp (F A)) (e₂ : cmp (F B)) (f : val A → val B → cmp X) →
+      (bind X e₁ λ x₁ → bind X e₂ λ x₂ → f x₁ x₂) ≡
+      (bind X e₂ λ x₂ → bind X e₁ λ x₁ → f x₁ x₂)
 
 
 
@@ -100,96 +103,100 @@ module Queue where
     coinductive
     field
       quit    : cmp X
-      enqueue : cmp (Π E λ _ → meta (Queue X))
-      dequeue : cmp (F (prod⁺ (maybe E) (U (queue X))))
+      enqueue : cmp (Π E λ _ → queue X)
+      dequeue : cmp (prod⁻ (◯⁻ (F (maybe E))) (queue X))
+      -- question: what about coproducts, e.g. dequeue : 1 + (E × queue X)
   queue X = meta (Queue X)
 
   postulate
-    quit/step    : ∀ {c e} → Queue.quit    (step (queue X) c e) ≡ step X                                   c (Queue.quit e)
-    enqueue/step : ∀ {c e} → Queue.enqueue (step (queue X) c e) ≡ step (Π E λ _ → queue X)                 c (Queue.enqueue e)
-    dequeue/step : ∀ {c e} → Queue.dequeue (step (queue X) c e) ≡ step (F (prod⁺ (maybe E) (U (queue X)))) c (Queue.dequeue e)
-  {-# REWRITE enqueue/step dequeue/step quit/step #-}
+    quit/step    : ∀ {c e} → Queue.quit    (step (queue X) c e) ≡ step X                                    c (Queue.quit e)
+    enqueue/step : ∀ {c e} → Queue.enqueue (step (queue X) c e) ≡ step (Π E λ _ → queue X)                  c (Queue.enqueue e)
+    dequeue/step : ∀ {c e} → Queue.dequeue (step (queue X) c e) ≡ step (prod⁻ (◯⁻ (F (maybe E))) (queue X)) c (Queue.dequeue e)
+  {-# REWRITE quit/step enqueue/step dequeue/step #-}
+
+  -- only *D*iscards cost
+  D : tp neg
+  D = [ F unit ∣ ext ↪ (λ _ → ret triv) ]
 
   {-# TERMINATING #-}
-  list-queue : cmp (Π (list E) λ _ → queue (F unit))
-  Queue.quit (list-queue l) = ret triv
-  Queue.enqueue (list-queue l) e = step (queue (F unit)) (length l) (list-queue (l ++ [ e ]))
-  Queue.dequeue (list-queue []) = ret (nothing , list-queue [])
-  Queue.dequeue (list-queue (e ∷ l)) = ret (just e , list-queue l)
+  list-queue : cmp (Π (list E) λ _ → queue D)
+  Queue.quit (list-queue l) = exactly (ret triv)
+  Queue.enqueue (list-queue l) e = step (queue D) (length l) (list-queue (l ++ [ e ]))
+  Queue.dequeue (list-queue []     ) = (λ _ → ret nothing)  , list-queue []
+  Queue.dequeue (list-queue (e ∷ l)) = (λ _ → ret (just e)) , list-queue l
 
   {-# TERMINATING #-}
-  SPEC/list-queue : cmp (Π (list E) λ _ → queue (F unit))
-  Queue.enqueue (SPEC/list-queue l) e = step (queue (F unit)) 1 (SPEC/list-queue (l ++ [ e ]))
-  Queue.dequeue (SPEC/list-queue []) = ret (nothing , SPEC/list-queue [])
-  Queue.dequeue (SPEC/list-queue (e ∷ l)) = ret (just e , SPEC/list-queue l)
-  Queue.quit (SPEC/list-queue l) = ret triv
+  SPEC/list-queue : cmp (Π (list E) λ _ → queue D)
+  Queue.quit (SPEC/list-queue l) = exactly (ret triv)
+  Queue.enqueue (SPEC/list-queue l) e = step (queue D) 1 (SPEC/list-queue (l ++ [ e ]))
+  Queue.dequeue (SPEC/list-queue []     ) = (λ _ → ret nothing)  , SPEC/list-queue []
+  Queue.dequeue (SPEC/list-queue (e ∷ l)) = (λ _ → ret (just e)) , SPEC/list-queue l
 
   Φ : val (list E) → val (list E) → ℂ
   Φ bl fl = length bl
 
   {-# TERMINATING #-}
-  batched-queue : cmp (Π (list E) λ _ → Π (list E) λ _ → queue (F unit))
-  Queue.quit (batched-queue bl fl) = step (F unit) (Φ bl fl) (ret triv)
+  batched-queue : cmp (Π (list E) λ _ → Π (list E) λ _ → queue D)
+  Queue.quit (batched-queue bl fl) = witnessed-by (step/ext (F unit) (ret triv) (Φ bl fl))
   Queue.enqueue (batched-queue bl fl) e = batched-queue (e ∷ bl) fl
   Queue.dequeue (batched-queue bl []) with reverse bl
-  ... | [] = ret (nothing , batched-queue [] [])
-  ... | e ∷ fl = step (F (prod⁺ (maybe E) (U (queue (F unit))))) (length bl) (ret (just e , batched-queue [] fl))
-  Queue.dequeue (batched-queue bl (e ∷ fl)) = ret (just e , batched-queue bl fl)
+  ... | [] = (λ _ → ret nothing) , batched-queue [] []
+  ... | e ∷ fl = step (prod⁻ (◯⁻ (F (maybe E))) (queue D)) (length bl) ((λ _ → ret (just e)) , batched-queue [] fl)
+  Queue.dequeue (batched-queue bl (e ∷ fl)) = (λ _ → ret (just e)) , batched-queue bl fl
 
   {-# TERMINATING #-}
-  SPEC/batched-queue : cmp (Π (list E) λ _ → Π (list E) λ _ → queue (F unit))
-  Queue.quit (SPEC/batched-queue bl fl) = ret triv
-  Queue.enqueue (SPEC/batched-queue bl fl) e = step (queue (F unit)) 1 (SPEC/batched-queue (e ∷ bl) fl)
+  SPEC/batched-queue : cmp (Π (list E) λ _ → Π (list E) λ _ → queue D)
+  Queue.quit (SPEC/batched-queue bl fl) = exactly (ret triv)
+  Queue.enqueue (SPEC/batched-queue bl fl) e = step (queue D) 1 (SPEC/batched-queue (e ∷ bl) fl)
   Queue.dequeue (SPEC/batched-queue bl []) with reverse bl
-  ... | [] = ret (nothing , SPEC/batched-queue [] [])
-  ... | e ∷ fl = ret (just e , SPEC/batched-queue [] fl)
-  Queue.dequeue (SPEC/batched-queue bl (e ∷ fl)) = ret (just e , SPEC/batched-queue bl fl)
+  ... | [] = (λ _ → ret nothing) , SPEC/batched-queue [] []
+  ... | e ∷ fl = (λ _ → ret (just e)) , SPEC/batched-queue [] fl
+  Queue.dequeue (SPEC/batched-queue bl (e ∷ fl)) = (λ _ → ret (just e)) , SPEC/batched-queue bl fl
 
   record _≈_ {X : tp neg} (q₁ q₂ : cmp (queue X)) : Set where
     coinductive
     field
-      quit    : cmp (F (U (meta (Queue.quit q₁ ≡ Queue.quit q₂))))
-      enqueue : cmp (Π E λ e → meta (Queue.enqueue q₁ e ≈ Queue.enqueue q₂ e))
-      dequeue :
-        ◯ (cmp (F (U (meta (bind (F (maybe E)) (Queue.dequeue q₁) (ret ∘ proj₁) ≡ bind (F (maybe E)) (Queue.dequeue q₂) (ret ∘ proj₁)))))) ×
-        (bind (queue X) (Queue.dequeue q₁) proj₂ ≈ bind (queue X) (Queue.dequeue q₂) proj₂)
+      quit    : cmp $
+        meta (Queue.quit q₁ ≡ Queue.quit q₂)
+      enqueue : cmp $
+        Π E λ e → meta (Queue.enqueue q₁ e ≈ Queue.enqueue q₂ e)
+      dequeue : cmp $
+        prod⁻
+          (ext/cmp λ u → meta (proj₁ (Queue.dequeue q₁) u ≡ proj₁ (Queue.dequeue q₂) u))
+          (meta (proj₂ (Queue.dequeue q₁) ≈ proj₂ (Queue.dequeue q₂)))
 
   ≈-cong : (c : ℂ) {x y : Queue X} → x ≈ y → step (queue X) c x ≈ step (queue X) c y
-  _≈_.quit (≈-cong {X = X} c {x} {y} h) = bind (F (U (meta (step X c (Queue.quit x) ≡ step X c (Queue.quit y))))) (_≈_.quit h) (ret ∘ Eq.cong (step X c))
+  _≈_.quit (≈-cong {X = X} c {x} {y} h) = Eq.cong (step X c) (_≈_.quit h)
   _≈_.enqueue (≈-cong c h) e = ≈-cong c (_≈_.enqueue h e)
   _≈_.dequeue (≈-cong {X} c {x} {y} h) =
-    (λ u →
-      bind
-        (F (U (meta (step (F (maybe E)) c (bind (F (maybe E)) (Queue.dequeue x) (ret ∘ proj₁)) ≡ step (F (maybe E)) c (bind (F (maybe E)) (Queue.dequeue y) (ret ∘ proj₁))))))
-        (proj₁ (_≈_.dequeue h) u)
-        (ret ∘ Eq.cong (step (F (maybe E)) c))) ,
+    (λ u → Eq.cong (step (F (maybe E)) c) (proj₁ (_≈_.dequeue h) u)) ,
     ≈-cong c (proj₂ (_≈_.dequeue h))
 
   {-# TERMINATING #-}
   batched-queue≈SPEC/batched-queue : (bl fl : val (list E)) →
-    batched-queue bl fl ≈ step (queue (F unit)) (Φ bl fl) (SPEC/batched-queue bl fl)
-  _≈_.quit (batched-queue≈SPEC/batched-queue bl fl) = ret refl
+    batched-queue bl fl ≈ step (queue D) (Φ bl fl) (SPEC/batched-queue bl fl)
+  _≈_.quit (batched-queue≈SPEC/batched-queue bl fl) = extension-≡ refl
   _≈_.enqueue (batched-queue≈SPEC/batched-queue bl fl) e =
     Eq.subst
-      (λ c → batched-queue (e ∷ bl) fl ≈ step (queue (F unit)) c (SPEC/batched-queue (e ∷ bl) fl))
+      (λ c → batched-queue (e ∷ bl) fl ≈ step (queue D) c (SPEC/batched-queue (e ∷ bl) fl))
       (Nat.+-comm 1 (length bl))
       (batched-queue≈SPEC/batched-queue (e ∷ bl) fl)
   _≈_.dequeue (batched-queue≈SPEC/batched-queue bl []) with reverse bl | List.reverse-injective {xs = bl} {ys = []}
-  ... | [] | h with h refl
-  ... | refl = (λ u → ret refl) , batched-queue≈SPEC/batched-queue [] []
+  _≈_.dequeue (batched-queue≈SPEC/batched-queue bl []) | [] | h with h refl
+  ... | refl = (λ _ → refl) , batched-queue≈SPEC/batched-queue [] []
   _≈_.dequeue (batched-queue≈SPEC/batched-queue bl []) | e ∷ fl | _ =
-    (λ u → ret refl) , ≈-cong (length bl) (batched-queue≈SPEC/batched-queue [] fl)
+    (λ _ → refl) , ≈-cong (Φ bl fl) (batched-queue≈SPEC/batched-queue [] fl)
   _≈_.dequeue (batched-queue≈SPEC/batched-queue bl (e ∷ fl)) =
-    (λ u → ret (Eq.sym (step/ext (F (maybe E)) (ret (just e)) (Φ bl fl) u))) ,
+    (λ u → Eq.sym (step/ext (F (maybe E)) (ret (just e)) (Φ bl fl) u)) ,
     batched-queue≈SPEC/batched-queue bl fl
 
   {-# TERMINATING #-}
   batched-queue≈SPEC/list-queue : (bl fl : val (list E)) →
-    batched-queue bl fl ≈ step (queue (F unit)) (Φ bl fl) (SPEC/list-queue (fl ++ reverse bl))
-  _≈_.quit (batched-queue≈SPEC/list-queue bl fl) = ret refl
+    batched-queue bl fl ≈ step (queue D) (Φ bl fl) (SPEC/list-queue (fl ++ reverse bl))
+  _≈_.quit (batched-queue≈SPEC/list-queue bl fl) = extension-≡ refl
   _≈_.enqueue (batched-queue≈SPEC/list-queue bl fl) e =
     Eq.subst₂
-      (λ c l → batched-queue (e ∷ bl) fl ≈ step (queue (F unit)) c (SPEC/list-queue l))
+      (λ c l → batched-queue (e ∷ bl) fl ≈ step (queue D) c (SPEC/list-queue l))
       (Nat.+-comm 1 (length bl))
       (let open ≡-Reasoning in
       begin
@@ -201,11 +208,11 @@ module Queue where
       ∎)
       (batched-queue≈SPEC/list-queue (e ∷ bl) fl)
   _≈_.dequeue (batched-queue≈SPEC/list-queue bl []) with reverse bl | List.reverse-injective {xs = bl} {ys = []}
-  ... | [] | h with h refl
+  _≈_.dequeue (batched-queue≈SPEC/list-queue bl []) | [] | h with h refl
   ... | refl =
-    (λ u → ret refl) , batched-queue≈SPEC/list-queue [] []
+    (λ _ → refl) , batched-queue≈SPEC/list-queue [] []
   _≈_.dequeue (batched-queue≈SPEC/list-queue bl []) | e ∷ fl | _ =
-    (λ u → ret refl) ,
+    (λ _ → refl) ,
     ≈-cong (length bl)
       ( Eq.subst
           (λ l → batched-queue [] fl ≈ SPEC/list-queue l)
@@ -213,17 +220,18 @@ module Queue where
           (batched-queue≈SPEC/list-queue [] fl)
       )
   _≈_.dequeue (batched-queue≈SPEC/list-queue bl (e ∷ fl)) =
-    (λ u → ret (Eq.sym (step/ext (F (maybe E)) (ret (just e)) (Φ bl fl) u))) ,
+    (λ u → Eq.sym (step/ext (F (maybe E)) (ret (just e)) (Φ bl fl) u)) ,
     batched-queue≈SPEC/list-queue bl fl
 
 
   {-# TERMINATING #-}
   ◯[list-queue≈batched-queue] : (bl fl : val (list E)) → ◯ (list-queue (fl ++ reverse bl) ≈ batched-queue bl fl)
-  _≈_.quit (◯[list-queue≈batched-queue] bl fl u) = ret (Eq.sym (step/ext (F unit) (ret triv) (length bl) u))
+  _≈_.quit (◯[list-queue≈batched-queue] bl fl u) =
+    extension-≡ (Eq.sym (step/ext (F unit) (ret triv) (length bl) u))
   _≈_.enqueue (◯[list-queue≈batched-queue] bl fl u) e =
     Eq.subst
       (_≈ Queue.enqueue (batched-queue bl fl) e)
-      (Eq.sym (step/ext (queue (F unit)) (list-queue _) (length (fl ++ reverse bl)) u))
+      (Eq.sym (step/ext (queue D) (list-queue _) (length (fl ++ reverse bl)) u))
       (Eq.subst
         (λ l → list-queue l ≈ batched-queue (e ∷ bl) fl)
         {x = fl ++ reverse (e ∷ bl)}
@@ -239,173 +247,171 @@ module Queue where
   _≈_.dequeue (◯[list-queue≈batched-queue] bl [] u) with reverse bl | List.reverse-injective {xs = bl} {ys = []}
   ... | [] | h with h refl
   ... | refl =
-    (λ u → ret refl) , ◯[list-queue≈batched-queue] [] [] u
+    (λ u → refl) , ◯[list-queue≈batched-queue] [] [] u
   _≈_.dequeue (◯[list-queue≈batched-queue] bl [] u) | e ∷ fl | _ =
-    (λ u → ret (Eq.sym (step/ext (F (maybe E)) (ret (just e)) (Φ bl fl) u))) ,
+    (λ u → Eq.sym (step/ext (F (maybe E)) (ret (just e)) (Φ bl fl) u)) ,
     Eq.subst₂
       _≈_
       (Eq.cong list-queue (List.++-identityʳ fl))
-      (Eq.sym (step/ext (queue (F unit)) (batched-queue [] fl) (Φ bl fl) u))
+      (Eq.sym (step/ext (queue D) (batched-queue [] fl) (Φ bl fl) u))
       (◯[list-queue≈batched-queue] [] fl u)
   _≈_.dequeue (◯[list-queue≈batched-queue] bl (e ∷ fl) u) =
-    (λ u → ret refl) , ◯[list-queue≈batched-queue] bl fl u
+    (λ u → refl) , ◯[list-queue≈batched-queue] bl fl u
 
   -- {-# TERMINATING #-}
   -- fake-queue : cmp (queue (F unit))
   -- Queue.quit fake-queue = ret triv
   -- Queue.enqueue fake-queue e = fake-queue
-  -- Queue.dequeue fake-queue = ret (nothing , fake-queue)
+  -- Queue.dequeue fake-queue = (λ _ → ret nothing) , fake-queue
 
   -- issue : (c₁ c₂ : ℂ) → step (queue (F unit)) c₁ fake-queue ≈ step (queue (F unit)) c₂ fake-queue
   -- _≈_.quit (issue c₁ c₂) = {!   !}
   -- _≈_.enqueue (issue c₁ c₂) e = issue c₁ c₂
   -- _≈_.dequeue (issue c₁ c₂) =
-  --   c₁ , nothing , fake-queue , refl ,
-  --   c₂ , nothing , fake-queue , refl ,
-  --   refl , issue c₁ c₂
+  --   (λ u →
+  --     let open ≡-Reasoning in
+  --     begin
+  --       step (F (maybe E)) c₁ (ret nothing)
+  --     ≡⟨ step/ext (F (maybe E)) (ret nothing) c₁ u ⟩
+  --       ret nothing
+  --     ≡˘⟨ step/ext (F (maybe E)) (ret nothing) c₂ u ⟩
+  --       step (F (maybe E)) c₂ (ret nothing)
+  --     ∎) ,
+  --   issue c₁ c₂
 
-  data QueueProgram (E : tp pos) (A : tp pos) : Set
-  queue-program : tp pos → tp pos → tp pos
+  data QueueProgram (A : tp pos) : Set
+  queue-program : tp pos → tp pos
 
-  data QueueProgram E A where
-    return : val A → QueueProgram E A
-    enqueue : val E → val (queue-program E A) → QueueProgram E A
-    dequeue : val (U (Π (maybe E) λ _ → F (queue-program E A))) → QueueProgram E A
-  queue-program E A = U (meta (QueueProgram E A))
+  data QueueProgram A where
+    return  : val A → QueueProgram A
+    enqueue : val E → val (queue-program A) → QueueProgram A
+    dequeue : val (U (Π (U (◯⁻ (F (maybe E)))) (λ _ → F (queue-program A)))) → QueueProgram A
+  queue-program A = U (meta (QueueProgram A))
 
   {-# TERMINATING #-}
-  ψ : cmp (Π (queue-program E A) λ _ → Π (U (queue (F unit))) λ _ → F A)
-  ψ {A = A} (return b) q = bind (F A) (Queue.quit q) λ _ → ret b
+  ψ : cmp (Π (queue-program A) λ _ → Π (U (queue D)) λ _ → F A)
+  ψ {A = A} (return b) q = bind (F A) (out (Queue.quit q)) λ _ → ret b
   ψ (enqueue e p) q = ψ p (Queue.enqueue q e)
   ψ {A = A} (dequeue f) q =
-    bind (F A) (Queue.dequeue q) λ (e , q') →
-    bind (F A) (f e) λ p' →
-    ψ p' q'
+    bind (F A) (f (proj₁ (Queue.dequeue q))) λ p' →
+    ψ p' (proj₂ (Queue.dequeue q))
 
-  step-ψ : ∀ c p q → step (F A) c (ψ p q) ≡ ψ p (step (queue (F unit)) c q)
-  step-ψ c (return x) q = refl
-  step-ψ c (enqueue e p) q = step-ψ c p (Queue.enqueue q e)
-  step-ψ c (dequeue f) q = refl
+  {-# TERMINATING #-}
+  step-ψ : StepCommutative → ∀ c p q → step (F A) c (ψ p q) ≡ ψ p (step (queue D) c q)
+  step-ψ step-commutative c (return x) q = refl
+  step-ψ step-commutative c (enqueue e p) q = step-ψ step-commutative c p (Queue.enqueue q e)
+  step-ψ {A} step-commutative c (dequeue f) q =
+    let open ≡-Reasoning in
+    begin
+      step (F A) c (ψ (dequeue f) q)
+    ≡⟨⟩
+      step (F A) c (
+        bind (F A) (f (proj₁ (Queue.dequeue q))) λ p' →
+        ψ p' (proj₂ (Queue.dequeue q))
+      )
+    ≡⟨
+      StepCommutative.step/bind step-commutative
+        {X = F A}
+        (f (proj₁ (Queue.dequeue q)))
+        (λ p' → ψ p' (proj₂ (Queue.dequeue q))) c
+    ⟩
+      ( bind (F A) (f (proj₁ (Queue.dequeue q))) λ p' →
+        step (F A) c (ψ p' (proj₂ (Queue.dequeue q)))
+      )
+    ≡⟨
+      Eq.cong
+        (bind (F A) (f (proj₁ (Queue.dequeue q))))
+        (funext λ p' → step-ψ step-commutative c p' (proj₂ (Queue.dequeue q)))
+    ⟩
+      ( bind (F A) (f (proj₁ (Queue.dequeue q))) λ p' →
+        ψ p' (proj₂ (Queue.dequeue (step (queue D) c q)))
+      )
+    ≡˘⟨
+      Eq.cong
+        (λ e → bind (F A) (f e) λ p' → ψ p' (proj₂ (Queue.dequeue (step (queue D) c q))))
+        (funext/Ω λ u → step/ext (F (maybe E)) (proj₁ (Queue.dequeue q) u) c u)
+    ⟩
+      ( bind (F A) (f (λ u → step (F (maybe E)) c (proj₁ (Queue.dequeue q) u))) λ p' →
+        ψ p' (step (queue D) c (proj₂ (Queue.dequeue q)))
+      )
+    ≡⟨⟩
+      ( bind (F A) (f (proj₁ (Queue.dequeue (step (queue D) c q)))) λ p' →
+        ψ p' (proj₂ (Queue.dequeue (step (queue D) c q)))
+      )
+    ≡⟨⟩
+      ψ (dequeue f) (step (queue D) c q)
+    ∎
 
   postulate
     step-ret-injective : (c₁ c₂ : ℂ) (v₁ v₂ : val A) →
       step (F A) c₁ (ret v₁) ≡ step (F A) c₂ (ret v₂) → v₁ ≡ v₂
 
-  _≈'_ : {E : tp pos} (q₁ q₂ : cmp (queue (F unit))) → Set
-  _≈'_ q₁ q₂ = ∀ A → cmp (Π (queue-program E A) λ p → F (U (meta (ψ p q₁ ≡ ψ p q₂))))
+  _≈'_ : (q₁ q₂ : cmp (queue D)) → Set
+  _≈'_ q₁ q₂ = (A : tp pos) (p : val (queue-program A)) → ψ p q₁ ≡ ψ p q₂
 
   {-# TERMINATING #-}
-  classic-amortization :
-    StepCommutative
-    → {q₁ q₂ : cmp (queue (F unit))}
-    → q₁ ≈ q₂ ⇔ q₁ ≈' q₂
-  classic-amortization comm = record
+  classic-amortization : {q₁ q₂ : cmp (queue D)} →
+    q₁ ≈ q₂ ⇔ q₁ ≈' q₂
+  classic-amortization = record
     { f = forward
     ; g = backward
     ; cong₁ = Eq.cong forward
     ; cong₂ = Eq.cong backward
     }
     where
-      forward : {q₁ q₂ : cmp (queue (F unit))} →
+      forward : {q₁ q₂ : cmp (queue D)} →
         q₁ ≈ q₂ → q₁ ≈' q₂
       forward {q₁} {q₂} h A (return x) =
-        bind (F (U (meta (ψ (return x) q₁ ≡ ψ (return x) q₂)))) (_≈_.quit h) λ h →
-        ret (Eq.cong (λ e → bind (F A) e (const (ret x))) h)
-      forward h A (enqueue e p) = forward (_≈_.enqueue h e) A p
+        Eq.cong (λ e → bind (F A) (out e) (const (ret x))) (_≈_.quit h)
+      forward h A (enqueue e p) =
+        forward (_≈_.enqueue h e) A p
       forward {q₁} {q₂} h A (dequeue f) =
-        ret (
-      -- with _≈_.dequeue h
-      -- ... | c₁ , e , q₁' , h₁ , c₂ , _ , q₂' , h₂ , refl , hq' =
-        let open ≡-Reasoning in
-        begin
-          ( bind (F A) (Queue.dequeue q₁) λ (e , q₁') →
-            bind (F A) (f e) λ p' →
-            ψ p' q₁' )
-        -- ≡⟨ Eq.cong (λ e → bind (F A) e λ (e , q₁') → bind (F A) (f e) λ p' → ψ p' q₁') h₁ ⟩
-        --   (bind (F A) (step (F (prod⁺ (maybe E) (U (queue (F unit))))) c₁ (ret (e , q₁'))) λ (e , q₁') →
-        --   bind (F A) (f e) λ p' →
-        --   ψ p' q₁')
-        -- ≡⟨⟩
-        --   step (F A) c₁ (
-        --   bind (F A) (f e) λ p' →
-        --   ψ p' q₁')
-        -- ≡˘⟨ bind/step/commutative {B = A} {c = c₁} {e = f e} ⟩
-        --   (bind (F A) (f e) λ p' →
-        --   step (F A) c₁ (ψ p' q₁'))
-        -- ≡⟨
-        --   Eq.cong (bind (F A) (f e)) (funext λ p' →
-        --   begin
-        --     step (F A) c₁ (ψ p' q₁')
-        --   ≡⟨ step-ψ c₁ p' q₁' ⟩
-        --     ψ p' (step (queue (F unit)) c₁ q₁')
-        --   ≡⟨ forward (step (queue (F unit)) c₁ q₁') (step (queue (F unit)) c₂ q₂') hq' A p' ⟩
-        --     ψ p' (step (queue (F unit)) c₂ q₂')
-        --   ≡˘⟨ step-ψ c₂ p' q₂' ⟩
-        --     step (F A) c₂ (ψ p' q₂')
-        --   ∎)
-        -- ⟩
-        --   (bind (F A) (f e) λ p' →
-        --   step (F A) c₂ (ψ p' q₂'))
-        -- ≡⟨ bind/step/commutative {B = A} {c = c₂} {e = f e} ⟩
-        --   step (F A) c₂ (
-        --   bind (F A) (f e) λ p' →
-        --   ψ p' q₂')
-        -- ≡⟨⟩
-        --   (bind (F A) (step (F (prod⁺ (maybe E) (U (queue (F unit))))) c₂ (ret (e , q₂'))) λ (e , q₂') →
-        --   bind (F A) (f e) λ p' →
-        --   ψ p' q₂')
-        -- ≡˘⟨ Eq.cong (λ e → bind (F A) e λ (e , q₂') → bind (F A) (f e) λ p' → ψ p' q₂') h₂ ⟩
-        ≡⟨ {! forward (proj₂ (_≈_.dequeue h)) A ?  !} ⟩
-          ( bind (F A) (Queue.dequeue q₂) λ (e , q₂') →
-            bind (F A) (f e) λ p' →
-            ψ p' q₂' )
-        ∎)
+        Eq.cong₂
+          (λ e₁ e₂ → bind (F A) (f e₁) e₂)
+          (funext/Ω λ u → proj₁ (_≈_.dequeue h) u)
+          (funext (forward (proj₂ (_≈_.dequeue h)) A))
 
-      bind-ψ : ∀ {B A} (e : cmp (F B)) f p → bind (F A) e (ψ p ∘ f) ≡ ψ p (bind (queue (F unit)) e f)
-      bind-ψ = {!   !}
-
-      backward : {q₁ q₂ : cmp (queue (F unit))} →
+      backward : {q₁ q₂ : cmp (queue D)} →
         q₁ ≈' q₂ → q₁ ≈ q₂
-      _≈_.quit (backward typical) = typical unit (return triv)
+      _≈_.quit (backward typical) = extension-≡ (typical unit (return triv))
       _≈_.enqueue (backward typical) e =
         backward (λ A p → typical A (enqueue e p))
       _≈_.dequeue (backward {q₁} {q₂} typical) =
         (λ u →
-          bind (F (U (meta (bind (F (maybe E)) (Queue.dequeue q₁) (ret ∘ proj₁) ≡ bind (F (maybe E)) (Queue.dequeue q₂) (ret ∘ proj₁))))) (typical (maybe E) (dequeue (λ e → ret (return e)))) λ h →
-          ret
-            ( let open ≡-Reasoning in
-              begin
-                bind (F (maybe E)) (Queue.dequeue q₁) (ret ∘ proj₁)
-              ≡⟨ {!   !} ⟩
-                ( bind (F (maybe E)) (Queue.dequeue q₁) λ (e , q₁') →
-                  bind (F (maybe E)) (Queue.quit q₁') λ _ →
-                  ret e )
-              ≡⟨⟩
-                ψ (dequeue (λ e → ret (return e))) q₁
-              ≡⟨ h ⟩
-                ψ (dequeue (λ e → ret (return e))) q₂
-              ≡⟨⟩
-                ( bind (F (maybe E)) (Queue.dequeue q₂) λ (e , q₂') →
-                  bind (F (maybe E)) (Queue.quit q₂') λ _ →
-                  ret e )
-              ≡⟨ {!   !} ⟩
-                bind (F (maybe E)) (Queue.dequeue q₂) (ret ∘ proj₁)
-              ∎
-            )) ,
-        backward (λ A p →
-          bind (F (U (meta (ψ p _ ≡ ψ p _)))) (typical A (dequeue (const (ret p)))) λ h →
-          ret
-            ( let open ≡-Reasoning in
-              begin
-                ψ p (bind (queue (F unit)) (Queue.dequeue q₁) proj₂)
-              ≡˘⟨ bind-ψ (Queue.dequeue q₁) proj₂ p ⟩
-                bind (F A) (Queue.dequeue q₁) (ψ p ∘ proj₂)
-              ≡⟨ h ⟩
-                bind (F A) (Queue.dequeue q₂) (ψ p ∘ proj₂)
-              ≡⟨ bind-ψ (Queue.dequeue q₂) proj₂ p ⟩
-                ψ p (bind (queue (F unit)) (Queue.dequeue q₂) proj₂)
-              ∎
-            ))
+          let open ≡-Reasoning in
+          begin
+            proj₁ (Queue.dequeue q₁) u
+          ≡˘⟨
+            Eq.cong
+              (λ x →
+                ( bind (F (maybe E)) (proj₁ (Queue.dequeue q₁) u) λ e →
+                  bind {unit} (F (maybe E)) x λ _ →
+                  ret e
+                ))
+              (law (Queue.quit (proj₂ (Queue.dequeue q₁))) u)
+          ⟩
+            ( bind (F (maybe E)) (proj₁ (Queue.dequeue q₁) u) λ e →
+              bind (F (maybe E)) (out (Queue.quit (proj₂ (Queue.dequeue q₁)))) λ _ →
+              ret e
+            )
+          ≡⟨ typical (maybe E) (dequeue (λ e → bind (F (queue-program (maybe E))) (e u) (ret ∘ return))) ⟩
+            ( bind (F (maybe E)) (proj₁ (Queue.dequeue q₂) u) λ e →
+              bind (F (maybe E)) (out (Queue.quit (proj₂ (Queue.dequeue q₂)))) λ _ →
+              ret e
+            )
+          ≡⟨
+            Eq.cong
+              (λ x →
+                ( bind (F (maybe E)) (proj₁ (Queue.dequeue q₂) u) λ e →
+                  bind {unit} (F (maybe E)) x λ _ →
+                  ret e
+                ))
+              (law (Queue.quit (proj₂ (Queue.dequeue q₂))) u)
+          ⟩
+            proj₁ (Queue.dequeue q₂) u
+          ∎
+        ) ,
+        backward λ A p → typical A (dequeue (λ _ → ret p))
 
 
 module DynamicArray where

--- a/src/Examples/Amortized.agda
+++ b/src/Examples/Amortized.agda
@@ -366,13 +366,13 @@ module DynamicArray where
     field
       quit   : cmp D
       append : cmp (Π A λ _ → dynamic-array A)
-      get    : cmp (Π nat λ _ → F (prod⁺ (maybe A) (U (dynamic-array A))))
+      get    : cmp (Π nat λ _ → prod⁻ (◯⁻ (F (maybe A))) (dynamic-array A))
   dynamic-array A = meta (DynamicArray A)
 
   postulate
-    quit/step   : ∀ {c e} → DynamicArray.quit   (step (dynamic-array A) c e) ≡ step D                                                       c (DynamicArray.quit   e)
-    append/step : ∀ {c e} → DynamicArray.append (step (dynamic-array A) c e) ≡ step (Π A λ _ → dynamic-array A)                             c (DynamicArray.append e)
-    get/step    : ∀ {c e} → DynamicArray.get    (step (dynamic-array A) c e) ≡ step (Π nat λ _ → F (prod⁺ (maybe A) (U (dynamic-array A)))) c (DynamicArray.get    e)
+    quit/step   : ∀ {c e} → DynamicArray.quit   (step (dynamic-array A) c e) ≡ step D                                                        c (DynamicArray.quit   e)
+    append/step : ∀ {c e} → DynamicArray.append (step (dynamic-array A) c e) ≡ step (Π A λ _ → dynamic-array A)                              c (DynamicArray.append e)
+    get/step    : ∀ {c e} → DynamicArray.get    (step (dynamic-array A) c e) ≡ step (Π nat λ _ → prod⁻ (◯⁻ (F (maybe A))) (dynamic-array A)) c (DynamicArray.get    e)
   {-# REWRITE quit/step append/step get/step #-}
 
   Φ : val nat → val nat → ℂ
@@ -387,39 +387,36 @@ module DynamicArray where
   DynamicArray.append (array n zero) triv = step (dynamic-array unit) (2 ^ n) (array (suc n) pred[2^ n ])
   DynamicArray.append (array n (suc m)) triv = array n m
   DynamicArray.get (array n m) i with i Nat.<? 2 ^ n ∸ m
-  ... | no ¬p = ret (nothing , array n m)
-  ... | yes p = ret (just triv , array n m)
+  ... | no ¬p = (λ _ → ret nothing) , array n m
+  ... | yes p = (λ _ → ret (just triv)) , array n m
 
   {-# TERMINATING #-}
   SPEC/array : cmp (Π nat λ _ → dynamic-array unit)
   DynamicArray.quit (SPEC/array n) = exactly
   DynamicArray.append (SPEC/array n) triv = step (dynamic-array unit) 2 (SPEC/array (suc n))
   DynamicArray.get (SPEC/array n) i with i Nat.<? n
-  ... | no ¬p = ret (nothing , SPEC/array n)
-  ... | yes p = ret (just triv , SPEC/array n)
+  ... | no ¬p = (λ _ → ret nothing) , SPEC/array n
+  ... | yes p = (λ _ → ret (just triv)) , SPEC/array n
 
   record _≈_ {A : tp pos} (d₁ d₂ : cmp (dynamic-array A)) : Set where
     coinductive
     field
-      quit : DynamicArray.quit d₁ ≡ DynamicArray.quit d₂
-      append : cmp (Π A λ a → meta (DynamicArray.append d₁ a ≈ DynamicArray.append d₂ a))
-      get :
-        (i : val nat) →
-          Σ ℂ λ c₁ → Σ (val (maybe A)) λ a₁ → Σ (cmp (dynamic-array A)) λ d₁' → DynamicArray.get d₁ i ≡ step (F (prod⁺ (maybe A) (U (dynamic-array A)))) c₁ (ret (a₁ , d₁')) ×
-          Σ ℂ λ c₂ → Σ (val (maybe A)) λ a₂ → Σ (cmp (dynamic-array A)) λ d₂' → DynamicArray.get d₂ i ≡ step (F (prod⁺ (maybe A) (U (dynamic-array A)))) c₂ (ret (a₂ , d₂')) ×
-          -- (c₁ ≡ c₂) ×  -- not amortized
-          (a₁ ≡ a₂) ×
-          -- (d₁' ≈ d₂')  -- not amortized
-          (step (dynamic-array A) c₁ d₁' ≈ step (dynamic-array A) c₂ d₂')  -- amortized
+      quit   : cmp $
+        meta (DynamicArray.quit d₁ ≡ DynamicArray.quit d₂)
+      append : cmp $
+        Π A λ a → meta (DynamicArray.append d₁ a ≈ DynamicArray.append d₂ a)
+      get    : cmp $
+        Π nat λ i →
+          prod⁻
+            (ext/cmp λ u → meta (proj₁ (DynamicArray.get d₁ i) u ≡ proj₁ (DynamicArray.get d₂ i) u))
+            (meta (proj₂ (DynamicArray.get d₁ i) ≈ proj₂ (DynamicArray.get d₂ i)))
 
   ≈-cong : (c : cmp cost) {x y : DynamicArray A} → x ≈ y → step (dynamic-array A) c x ≈ step (dynamic-array A) c y
   _≈_.quit (≈-cong c h) = Eq.cong (step D c) (_≈_.quit h)
   _≈_.append (≈-cong c h) a = ≈-cong c (_≈_.append h a)
   _≈_.get (≈-cong {A} c h) i =
-    let (c₁ , a₁ , d₁' , h₁ , c₂ , a₂ , d₂' , h₂ , ha , hd') = _≈_.get h i in
-    c + c₁ , a₁ , d₁' , Eq.cong (step (F (prod⁺ (maybe A) (U (dynamic-array A)))) c) h₁ ,
-    c + c₂ , a₂ , d₂' , Eq.cong (step (F (prod⁺ (maybe A) (U (dynamic-array A)))) c) h₂ ,
-    ha , ≈-cong c hd'
+    (λ u → Eq.cong (step (F (maybe A)) c) (proj₁ (_≈_.get h i) u)) ,
+    ≈-cong c (proj₂ (_≈_.get h i))
 
   -- from unreleased agda-stdlib
   2^n>0 : ∀ (n : ℕ) → 2 ^ n > 0
@@ -519,10 +516,8 @@ module DynamicArray where
       (array≈SPEC/array n m (Nat.<⇒≤ h))
   _≈_.get (array≈SPEC/array n m h) i with i Nat.<? 2 ^ n ∸ m
   ... | no ¬p =
-          zero , nothing , array n m , refl ,
-          2 ^ n ∸ 2 * m , nothing , SPEC/array (2 ^ n ∸ m) , refl ,
-          refl , array≈SPEC/array n m h
+          (λ u → Eq.sym (step/ext (F (maybe unit)) (ret nothing) (2 ^ n ∸ 2 * m) u)) ,
+          array≈SPEC/array n m h
   ... | yes p =
-          zero , just triv , array n m , refl ,
-          2 ^ n ∸ 2 * m , just triv , SPEC/array (2 ^ n ∸ m) , refl ,
-          refl , array≈SPEC/array n m h
+          (λ u → Eq.sym (step/ext (F (maybe unit)) (ret (just triv)) (2 ^ n ∸ 2 * m) u)) ,
+          array≈SPEC/array n m h

--- a/src/Examples/Amortized.agda
+++ b/src/Examples/Amortized.agda
@@ -34,20 +34,20 @@ variable
 
 
 module Simple where
-  record Simple : Set
-  simple : tp neg
-
-  record Simple where
+  postulate
+    simple : tp neg
+  record Simple : Set where
     coinductive
     field
       here : cmp (F unit)
       next : cmp simple
-  simple = meta Simple
-
   postulate
+    simple/decode : val (U simple) ≡ Simple
+    {-# REWRITE simple/decode #-}
+
     here/step : ∀ {c e} → Simple.here (step simple c e) ≡ step (F unit) c (Simple.here e)
     next/step : ∀ {c e} → Simple.next (step simple c e) ≡ step simple   c (Simple.next e)
-  {-# REWRITE here/step next/step #-}
+    {-# REWRITE here/step next/step #-}
 
   {-# TERMINATING #-}
   every : cmp simple
@@ -86,22 +86,22 @@ module Queue where
   E : tp pos
   E = nat
 
-  record Queue (X : tp neg) : Set
-  queue : tp neg → tp neg
-
-  record Queue X where
+  postulate
+    queue : tp neg → tp neg
+  record Queue (X : tp neg) : Set where
     coinductive
     field
       quit    : cmp X
       enqueue : cmp (Π E λ _ → queue X)
       dequeue : cmp (prod⁻ (◯⁻ (F (maybe E))) (queue X))
-  queue X = meta (Queue X)
-
   postulate
+    queue/decode : val (U (queue X)) ≡ Queue X
+    {-# REWRITE queue/decode #-}
+
     quit/step    : ∀ {c e} → Queue.quit    (step (queue X) c e) ≡ step X                                    c (Queue.quit e)
     enqueue/step : ∀ {c e} → Queue.enqueue (step (queue X) c e) ≡ step (Π E λ _ → queue X)                  c (Queue.enqueue e)
     dequeue/step : ∀ {c e} → Queue.dequeue (step (queue X) c e) ≡ step (prod⁻ (◯⁻ (F (maybe E))) (queue X)) c (Queue.dequeue e)
-  {-# REWRITE quit/step enqueue/step dequeue/step #-}
+    {-# REWRITE quit/step enqueue/step dequeue/step #-}
 
   -- only *D*iscards cost
   D : tp neg
@@ -268,14 +268,15 @@ module Queue where
   --     ∎) ,
   --   issue c₁ c₂
 
-  data QueueProgram (A : tp pos) : Set
-  queue-program : tp pos → tp pos
-
-  data QueueProgram A where
+  postulate
+    queue-program : tp pos → tp pos
+  data QueueProgram (A : tp pos) : Set where
     return  : val A → QueueProgram A
     enqueue : val E → val (queue-program A) → QueueProgram A
     dequeue : val (U (Π (U (◯⁻ (F (maybe E)))) (λ _ → F (queue-program A)))) → QueueProgram A
-  queue-program A = U (meta (QueueProgram A))
+  postulate
+    queue-program/decode : val (queue-program A) ≡ QueueProgram A
+    {-# REWRITE queue-program/decode #-}
 
   {-# TERMINATING #-}
   ψ : cmp (Π (queue-program A) λ _ → Π (U (queue D)) λ _ → F A)
@@ -357,22 +358,22 @@ module DynamicArray where
   D : tp neg
   D = [ F unit ∣ ext ↪ (λ _ → ret triv) ]
 
-  record DynamicArray (A : tp pos) : Set
-  dynamic-array : tp pos → tp neg
-
-  record DynamicArray A where
+  postulate
+    dynamic-array : tp pos → tp neg
+  record DynamicArray (A : tp pos) : Set where
     coinductive
     field
       quit   : cmp D
       append : cmp (Π A λ _ → dynamic-array A)
       get    : cmp (Π nat λ _ → prod⁻ (◯⁻ (F (maybe A))) (dynamic-array A))
-  dynamic-array A = meta (DynamicArray A)
-
   postulate
+    dynamic-array/decode : val (U (dynamic-array A)) ≡ DynamicArray A
+    {-# REWRITE dynamic-array/decode #-}
+
     quit/step   : ∀ {c e} → DynamicArray.quit   (step (dynamic-array A) c e) ≡ step D                                                        c (DynamicArray.quit   e)
     append/step : ∀ {c e} → DynamicArray.append (step (dynamic-array A) c e) ≡ step (Π A λ _ → dynamic-array A)                              c (DynamicArray.append e)
     get/step    : ∀ {c e} → DynamicArray.get    (step (dynamic-array A) c e) ≡ step (Π nat λ _ → prod⁻ (◯⁻ (F (maybe A))) (dynamic-array A)) c (DynamicArray.get    e)
-  {-# REWRITE quit/step append/step get/step #-}
+    {-# REWRITE quit/step append/step get/step #-}
 
   Φ : val nat → val nat → ℂ
   Φ n m = 2 ^ n ∸ 2 * m

--- a/src/Examples/Amortized.agda
+++ b/src/Examples/Amortized.agda
@@ -240,7 +240,7 @@ module Queue where
         ∎)
         (◯[list-queue≈batched-queue] (e ∷ bl) fl u))
   _≈_.dequeue (◯[list-queue≈batched-queue] bl [] u) with reverse bl | List.reverse-injective {xs = bl} {ys = []}
-  ... | [] | h with h refl
+  _≈_.dequeue (◯[list-queue≈batched-queue] bl [] u) | [] | h with h refl
   ... | refl =
     refl , ◯[list-queue≈batched-queue] [] [] u
   _≈_.dequeue (◯[list-queue≈batched-queue] bl [] u) | e ∷ fl | _ =
@@ -270,7 +270,7 @@ module Queue where
   ψ (dequeue f  ) q = ψ (f (proj₁ (Queue.dequeue q))) (proj₂ (Queue.dequeue q))
 
   _≈'_ : (q₁ q₂ : cmp (queue X)) → Set
-  _≈'_ q₁ q₂ = (A : tp pos) (p : val (queue-program A)) → ψ p q₁ ≡ ψ p q₂
+  q₁ ≈' q₂ = (A : tp pos) (p : val (queue-program A)) → ψ p q₁ ≡ ψ p q₂
 
   classic-amortization : {q₁ q₂ : cmp (queue X)} → q₁ ≈ q₂ ⇔ q₁ ≈' q₂
   classic-amortization {X} = record

--- a/src/Examples/Amortized.agda
+++ b/src/Examples/Amortized.agda
@@ -354,19 +354,21 @@ module Queue where
 
 
 module DynamicArray where
-  record DynamicArray (A : tp pos) : Set where
+  record DynamicArray (A : tp pos) : Set
+  dynamic-array : tp pos → tp neg
+
+  record DynamicArray A where
     coinductive
     field
-      quit : cmp (F unit)
-      append : cmp (Π A λ _ → meta (DynamicArray A))
-      get : cmp (Π nat λ _ → F (prod⁺ (maybe A) (U (meta (DynamicArray A)))))
-  dynamic-array : tp pos → tp neg
+      quit   : cmp (F unit)
+      append : cmp (Π A λ _ → dynamic-array A)
+      get    : cmp (Π nat λ _ → F (prod⁺ (maybe A) (U (dynamic-array A))))
   dynamic-array A = meta (DynamicArray A)
 
   postulate
-    quit/step   : ∀ {c e} → DynamicArray.quit   (step (dynamic-array A) c e) ≡ step (F unit)                                                      c (DynamicArray.quit   e)
-    append/step : ∀ {c e} → DynamicArray.append (step (dynamic-array A) c e) ≡ step (Π A λ _ → dynamic-array A)                                   c (DynamicArray.append e)
-    get/step    : ∀ {c e} → DynamicArray.get    (step (dynamic-array A) c e) ≡ step (Π nat λ _ → F (prod⁺ (maybe A) (U (meta (DynamicArray A))))) c (DynamicArray.get    e)
+    quit/step   : ∀ {c e} → DynamicArray.quit   (step (dynamic-array A) c e) ≡ step (F unit)                                                c (DynamicArray.quit   e)
+    append/step : ∀ {c e} → DynamicArray.append (step (dynamic-array A) c e) ≡ step (Π A λ _ → dynamic-array A)                             c (DynamicArray.append e)
+    get/step    : ∀ {c e} → DynamicArray.get    (step (dynamic-array A) c e) ≡ step (Π nat λ _ → F (prod⁺ (maybe A) (U (dynamic-array A)))) c (DynamicArray.get    e)
   {-# REWRITE quit/step append/step get/step #-}
 
   Φ : val nat → val nat → ℂ
@@ -399,8 +401,8 @@ module DynamicArray where
       append : cmp (Π A λ a → meta (DynamicArray.append d₁ a ≈ DynamicArray.append d₂ a))
       get :
         (i : val nat) →
-          Σ ℂ λ c₁ → Σ (val (maybe A)) λ a₁ → Σ (cmp (dynamic-array A)) λ d₁' → DynamicArray.get d₁ i ≡ step (F (prod⁺ (maybe A) (U (meta (DynamicArray A))))) c₁ (ret (a₁ , d₁')) ×
-          Σ ℂ λ c₂ → Σ (val (maybe A)) λ a₂ → Σ (cmp (dynamic-array A)) λ d₂' → DynamicArray.get d₂ i ≡ step (F (prod⁺ (maybe A) (U (meta (DynamicArray A))))) c₂ (ret (a₂ , d₂')) ×
+          Σ ℂ λ c₁ → Σ (val (maybe A)) λ a₁ → Σ (cmp (dynamic-array A)) λ d₁' → DynamicArray.get d₁ i ≡ step (F (prod⁺ (maybe A) (U (dynamic-array A)))) c₁ (ret (a₁ , d₁')) ×
+          Σ ℂ λ c₂ → Σ (val (maybe A)) λ a₂ → Σ (cmp (dynamic-array A)) λ d₂' → DynamicArray.get d₂ i ≡ step (F (prod⁺ (maybe A) (U (dynamic-array A)))) c₂ (ret (a₂ , d₂')) ×
           -- (c₁ ≡ c₂) ×  -- not amortized
           (a₁ ≡ a₂) ×
           -- (d₁' ≈ d₂')  -- not amortized

--- a/src/Examples/Amortized.agda
+++ b/src/Examples/Amortized.agda
@@ -95,7 +95,6 @@ module Queue where
       quit    : cmp X
       enqueue : cmp (Π E λ _ → queue X)
       dequeue : cmp (prod⁻ (◯⁻ (F (maybe E))) (queue X))
-      -- question: what about coproducts, e.g. dequeue : 1 + (E × queue X)
   queue X = meta (Queue X)
 
   postulate
@@ -300,11 +299,11 @@ module Queue where
     where
       forward : {q₁ q₂ : cmp (queue D)} →
         q₁ ≈ q₂ → q₁ ≈' q₂
-      forward {q₁} {q₂} h A (return x) =
+      forward h A (return x) =
         Eq.cong (λ e → bind (F A) (out e) (const (ret x))) (_≈_.quit h)
       forward h A (enqueue e p) =
         forward (_≈_.enqueue h e) A p
-      forward {q₁} {q₂} h A (dequeue f) =
+      forward h A (dequeue f) =
         Eq.cong₂
           (λ e₁ e₂ → bind (F A) (f e₁) e₂)
           (funext/Ω λ u → proj₁ (_≈_.dequeue h) u)


### PR DESCRIPTION
Big idea:
- [x] Change `dequeue` type from `F (prod⁺ (maybe E) (U (queue X)))` to `maybe E ⋉ queue X`.
  - Cost propagates into the right component.
  - The equivalence principle `≈` is then the natural choice of bisimulation for `queue X`; by construction, no cost goes to computing the value component.
- [x] Change `ψ` output type from `F A` to `A ⋉ X`.