### PR TITLE
remove scary equality rules?

### DIFF
--- a/src/Calf/Noninterference.agda
+++ b/src/Calf/Noninterference.agda
@@ -28,9 +28,9 @@ oblivious {A} {B} f c e = funext/Ω (λ u →
 unique : ∀ {A} → (a : val (● A)) → (u : ext) → a ≡ ∗ u
 unique {A} a u =
   eq/ref
-  (●/ind {A} a (λ a → F (eq (● A) a (∗ u)))
-  (λ a → ret (eq/intro (η≡∗ a u)))
-  (λ u → ret (eq/intro refl))
+  (●/ind {A} a (λ a → val (eq (● A) a (∗ u)))
+  (λ a → eq/intro (η≡∗ a u))
+  (λ u → eq/intro refl)
   (λ a u → eq/uni _ _ u))
 
 constant : ∀ {A B} (f : val (● A) → val (◯⁺ B)) →

--- a/src/Calf/PhaseDistinction.agda
+++ b/src/Calf/PhaseDistinction.agda
@@ -87,20 +87,20 @@ postulate
   η : ∀ {A} → val A → val (● A)
   ∗ : ∀ {A} → ext → val (● A)
   η≡∗ : ∀ {A} (a : val A) u → η {A} a ≡ ∗ u
-  ●/ind : ∀ {A} (a : val (● A)) (X : val (● A) → tp neg)
-    (x0 : (a : val A) → cmp (X (η a))) →
-    (x1 : (u : ext) → cmp (X (∗ u))) →
-    ((a : val A) → (u : ext) → P.subst (λ a → cmp (X a)) (η≡∗ a u) (x0 a) ≡ x1 u ) →
-    cmp (X a)
-  ●/ind/β₁ : ∀ {A} (a : val A) (X : val (● A) → tp neg)
-    (x0 : (a : val A) → cmp (X (η a))) →
-    (x1 : (u : ext) → cmp (X (∗ u))) →
-    (h : (a : val A) → (u : ext) → P.subst (λ a → cmp (X a)) (η≡∗ a u) (x0 a) ≡ x1 u ) →
+  ●/ind : ∀ {A} (a : val (● A)) (X : val (● A) → □)
+    (x0 : (a : val A) → X (η a)) →
+    (x1 : (u : ext) → X (∗ u)) →
+    ((a : val A) → (u : ext) → P.subst (λ a → X a) (η≡∗ a u) (x0 a) ≡ x1 u ) →
+    X a
+  ●/ind/β₁ : ∀ {A} (a : val A) (X : val (● A) → □)
+    (x0 : (a : val A) → X (η a)) →
+    (x1 : (u : ext) → X (∗ u)) →
+    (h : (a : val A) → (u : ext) → P.subst (λ a → X a) (η≡∗ a u) (x0 a) ≡ x1 u ) →
     ●/ind (η a) X x0 x1 h ≡ x0 a
   {-# REWRITE ●/ind/β₁ #-}
-  ●/ind/β₂ : ∀ {A} (u : ext) (X : val (● A) → tp neg)
-    (x0 : (a : val A) → cmp (X (η a))) →
-    (x1 : (u : ext) → cmp (X (∗ u))) →
-    (h : (a : val A) → (u : ext) → P.subst (λ a → cmp (X a)) (η≡∗ a u) (x0 a) ≡ x1 u ) →
+  ●/ind/β₂ : ∀ {A} (u : ext) (X : val (● A) → □)
+    (x0 : (a : val A) → X (η a)) →
+    (x1 : (u : ext) → X (∗ u)) →
+    (h : (a : val A) → (u : ext) → P.subst (λ a → X a) (η≡∗ a u) (x0 a) ≡ x1 u ) →
     ●/ind (∗ u) X x0 x1 h ≡ x1 u
   {-# REWRITE ●/ind/β₂ #-}

--- a/src/Calf/Types/Eq.agda
+++ b/src/Calf/Types/Eq.agda
@@ -12,7 +12,8 @@ open import Relation.Binary.PropositionalEquality
 postulate
   eq : (A : tp pos) → val A → val A → tp pos
   eq/intro : ∀ {A v1 v2} → v1 ≡ v2 → val (eq A v1 v2)
-  eq/ref : ∀ {A v1 v2} → cmp (F (eq A v1 v2)) → v1 ≡ v2
+  
+  eq/ref : ∀ {A v1 v2} → val (eq A v1 v2) → v1 ≡ v2
 
-  eq/uni : ∀ {A v1 v2} → (p q : cmp (F (eq A v1 v2))) →
+  eq/uni : ∀ {A v1 v2} → (p q : val (eq A v1 v2)) →
     (u : ext) → p ≡ q


### PR DESCRIPTION
These rules are true for the writer model, but extremely suspect for any other effect. `index.agda` builds fine with these rules replaced by the good ones (in this PR), but I noticed that many examples (under `Parallel`) may make use of the scary rules --- but these examples do not build even on `main`.