### PR TITLE
Compatibility with Mikan

### DIFF
--- a/.github/docs-toolchains.json
+++ b/.github/docs-toolchains.json
@@ -1,0 +1,30 @@
+{
+  "current": {
+    "agda_version": "2.8.0",
+    "nixpkgs_ref": "d351d0653aeb7877273920cd3e823994e7579b0b",
+    "dependency_repository": "agda/cubical",
+    "dependency_ref": "b150186d2544e7efeddd31e5d14a8b9ecbb100f7",
+    "dependency_library": "cubical.agda-lib"
+  },
+  "v1.0.0": {
+    "agda_version": "2.6.2.2",
+    "nixpkgs_ref": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+    "dependency_repository": "agda/agda-stdlib",
+    "dependency_ref": "v1.7",
+    "dependency_library": "standard-library.agda-lib"
+  },
+  "v1.1.0": {
+    "agda_version": "2.6.3",
+    "nixpkgs_ref": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
+    "dependency_repository": "agda/agda-stdlib",
+    "dependency_ref": "fc473ec905ab1a11a16718a7e8b628f1ab7eb435",
+    "dependency_library": "standard-library.agda-lib"
+  },
+  "v2.0.0": {
+    "agda_version": "2.6.3",
+    "nixpkgs_ref": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
+    "dependency_repository": "agda/agda-stdlib",
+    "dependency_ref": "fc473ec905ab1a11a16718a7e8b628f1ab7eb435",
+    "dependency_library": "standard-library.agda-lib"
+  }
+}

--- a/.github/workflows/agda.yaml
+++ b/.github/workflows/agda.yaml
@@ -1,101 +1,143 @@
-name: Compile Agda and Deploy HTML
+name: Agda and Mikan
+
 on:
   push:
-    branches:
-      - main
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
-  build:
+  typecheck:
+    name: Typecheck with ${{ matrix.name }}
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     strategy:
+      fail-fast: false
       matrix:
-        agda-ref: ["v2.6.3"]
-        stdlib-ref: ["v2.0"]
-        ghc-ver: ["8.10.2"]
-        cabal-ver: ["3.4.0.0"]
+        include:
+          - name: Agda 2.8.0 + Cubical 0.9
+            toolchain: agda
+            command: agda
+            typecheck-command: agda --cubical --guardedness --library-file="$GITHUB_WORKSPACE/libraries" --build-library
+            compiler-url: https://github.com/agda/agda.git
+            compiler-ref: 3d04bacca842729f9c0869b9287256321b5f450f
+            cubical-url: https://github.com/agda/cubical.git
+            cubical-ref: b150186d2544e7efeddd31e5d14a8b9ecbb100f7
+          - name: Mikan + Mikan Cubical
+            toolchain: mikan
+            command: mikan
+            typecheck-command: mikan --library-file="$GITHUB_WORKSPACE/libraries" --build-library
+            compiler-url: https://codeberg.org/1lab/mikan.git
+            compiler-ref: 0513ea707f9879fd60fedcd868aae36c208d5f9d
+            cubical-url: https://codeberg.org/1lab/agda-cubical.git
+            cubical-ref: 7a99d6e2834053b72b33a051d2798e673bbbae76
+
     steps:
-    - uses: actions/cache@v2
-      name: Cache cabal packages
-      id: cache-cabal
-      with:
-        path: |
-          ~/.cabal/packages
-          ~/.cabal/store
-          ~/.cabal/bin
-          ~/.local/bin
-          dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc-ver }}-${{ matrix.cabal-ver }}-${{ matrix.agda-ref }}
-    - name: Install cabal
-      if: steps.cache-cabal.outputs.cache-hit != 'true'
-      uses: actions/setup-haskell@v1.1.3
-      with:
-        ghc-version: ${{ matrix.ghc-ver }}
-        cabal-version: ${{ matrix.cabal-ver }}
-    - name: Put cabal programs in PATH
-      run: echo "~/.cabal/bin" >> $GITHUB_PATH
-    - name: Download Agda from github
-      if: steps.cache-cabal.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
-      with:
-        repository: agda/agda
-        path: agda
-        ref: ${{ matrix.agda-ref }}
+      - name: Check out calf
+        uses: actions/checkout@v4
+        with:
+          path: calf
 
-    - name: Install Agda
-      if: steps.cache-cabal.outputs.cache-hit != 'true'
-      run: |
-        cabal update
-        cabal install --overwrite-policy=always --ghc-options='-O2 +RTS -M6G -RTS' alex-3.2.5
-        cabal install --overwrite-policy=always --ghc-options='-O2 +RTS -M6G -RTS' happy-1.19.12
-        cd agda
-        mkdir -p doc
-        touch doc/user-manual.pdf
-        cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS'
+      - name: Set up Haskell
+        if: matrix.toolchain == 'agda'
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: 9.12.2
+          cabal-version: 3.12.1.0
+          cabal-update: false
 
+      - name: Restore Agda compiler cache
+        if: matrix.toolchain == 'agda'
+        id: agda-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/bin
+            ~/.cabal/packages
+            ~/.cabal/store
+          key: agda-${{ runner.os }}-${{ runner.arch }}-ghc-9.12.2-cabal-3.12.1.0-${{ matrix.compiler-ref }}
 
-    - name: Checkout standard library
-      uses: actions/checkout@v2
-      with:
-        repository: agda/agda-stdlib
-        path: stdlib
-        ref: ${{ matrix.stdlib-ref }}
+      - name: Install Nix
+        if: matrix.toolchain == 'mikan'
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+            cores = 4
+            max-jobs = 1
 
-    - name: Put standard library in Agda library list
-      run: |
-        mkdir -p ~/.agda/
-        touch ~/.agda/libraries
-        echo "$GITHUB_WORKSPACE/stdlib/standard-library.agda-lib" > ~/.agda/libraries
+      - name: Enable the Mikan binary cache
+        if: matrix.toolchain == 'mikan'
+        uses: cachix/cachix-action@v17
+        with:
+          name: mikan
+          skipPush: true
 
+      - name: Check out ${{ matrix.toolchain }}
+        if: matrix.toolchain == 'mikan' || steps.agda-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git init compiler
+          git -C compiler remote add origin "${{ matrix.compiler-url }}"
+          git -C compiler fetch --depth=1 origin "${{ matrix.compiler-ref }}"
+          git -C compiler checkout --detach FETCH_HEAD
 
-    - name: Checkout main
-      uses: actions/checkout@v2
-      with:
-        path: main
+      - name: Build and install Agda
+        if: matrix.toolchain == 'agda' && steps.agda-cache.outputs.cache-hit != 'true'
+        working-directory: compiler
+        run: |
+          cabal update
+          cabal install \
+            --overwrite-policy=always \
+            --ghc-options='-O1 +RTS -M6G -RTS' \
+            exe:agda
 
-    - name: Compile main library
-      run: |
-        mkdir -p ~/main-build/_build
-        cp -f -R ~/main-build/_build $GITHUB_WORKSPACE/main/_build
-        rm -r ~/main-build
-        cd main
-        agda --html --html-dir=docs src/index.agda
-        cp Agda.css docs/
-        cd ..
-        cp -f -R main/ ~/main-build/
+      - name: Add Agda to PATH
+        if: matrix.toolchain == 'agda'
+        run: echo "$HOME/.cabal/bin" >> "$GITHUB_PATH"
 
-    - name: Deploy html to github pages
-      if: ${{ github.event_name == 'push' }}
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: main/docs
+      - name: Restore or build Mikan through Cachix
+        if: matrix.toolchain == 'mikan'
+        run: |
+          nix build \
+            --accept-flake-config \
+            --out-link "$GITHUB_WORKSPACE/mikan-result" \
+            "$GITHUB_WORKSPACE/compiler"
+          echo "$GITHUB_WORKSPACE/mikan-result/bin" >> "$GITHUB_PATH"
+
+      - name: Check out the matching Cubical library
+        shell: bash
+        run: |
+          git init cubical
+          git -C cubical remote add origin "${{ matrix.cubical-url }}"
+          git -C cubical fetch --depth=1 origin "${{ matrix.cubical-ref }}"
+          git -C cubical checkout --detach FETCH_HEAD
+
+      - name: Register the Cubical library
+        shell: bash
+        run: |
+          printf '%s\n' "$GITHUB_WORKSPACE/cubical/cubical.agda-lib" > "$GITHUB_WORKSPACE/libraries"
+
+      - name: Remove Agda-only flags for Mikan
+        if: matrix.toolchain == 'mikan'
+        run: sed -i '/^flags:/d' calf/calf.agda-lib
+
+      - name: Restore compiler interface cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            calf/_build
+            cubical/_build
+          key: interfaces-${{ runner.os }}-${{ runner.arch }}-${{ matrix.toolchain }}-${{ matrix.compiler-ref }}-${{ matrix.cubical-ref }}-${{ hashFiles('calf/**/*.agda', 'calf/**/*.agda-lib') }}
+          restore-keys: |
+            interfaces-${{ runner.os }}-${{ runner.arch }}-${{ matrix.toolchain }}-${{ matrix.compiler-ref }}-${{ matrix.cubical-ref }}-
+
+      - name: Show compiler version
+        run: ${{ matrix.command }} --version
+
+      - name: Typecheck calf
+        working-directory: calf
+        run: ${{ matrix.typecheck-command }}

--- a/.github/workflows/agda.yaml
+++ b/.github/workflows/agda.yaml
@@ -21,15 +21,13 @@ jobs:
             toolchain: agda
             command: agda
             typecheck-command: agda --cubical --guardedness --library-file="$GITHUB_WORKSPACE/libraries" --build-library
-            compiler-url: https://github.com/agda/agda.git
-            compiler-ref: 3d04bacca842729f9c0869b9287256321b5f450f
+            compiler-ref: d351d0653aeb7877273920cd3e823994e7579b0b
             cubical-url: https://github.com/agda/cubical.git
             cubical-ref: b150186d2544e7efeddd31e5d14a8b9ecbb100f7
           - name: Mikan + Mikan Cubical
             toolchain: mikan
             command: mikan
             typecheck-command: mikan --library-file="$GITHUB_WORKSPACE/libraries" --build-library
-            compiler-url: https://codeberg.org/1lab/mikan.git
             compiler-ref: 0513ea707f9879fd60fedcd868aae36c208d5f9d
             cubical-url: https://codeberg.org/1lab/agda-cubical.git
             cubical-ref: 7a99d6e2834053b72b33a051d2798e673bbbae76
@@ -40,27 +38,7 @@ jobs:
         with:
           path: calf
 
-      - name: Set up Haskell
-        if: matrix.toolchain == 'agda'
-        uses: haskell-actions/setup@v2
-        with:
-          ghc-version: 9.12.2
-          cabal-version: 3.12.1.0
-          cabal-update: false
-
-      - name: Restore Agda compiler cache
-        if: matrix.toolchain == 'agda'
-        id: agda-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cabal/bin
-            ~/.cabal/packages
-            ~/.cabal/store
-          key: agda-${{ runner.os }}-${{ runner.arch }}-ghc-9.12.2-cabal-3.12.1.0-${{ matrix.compiler-ref }}
-
       - name: Install Nix
-        if: matrix.toolchain == 'mikan'
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
@@ -75,33 +53,19 @@ jobs:
           name: mikan
           skipPush: true
 
-      - name: Check out ${{ matrix.toolchain }}
-        if: matrix.toolchain == 'mikan' || steps.agda-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          git init compiler
-          git -C compiler remote add origin "${{ matrix.compiler-url }}"
-          git -C compiler fetch --depth=1 origin "${{ matrix.compiler-ref }}"
-          git -C compiler checkout --detach FETCH_HEAD
-
-      - name: Build and install Agda
-        if: matrix.toolchain == 'agda' && steps.agda-cache.outputs.cache-hit != 'true'
-        working-directory: compiler
-        run: |
-          cabal update
-          cabal install \
-            --overwrite-policy=always \
-            --ghc-options='-O1 +RTS -M6G -RTS' \
-            exe:agda
-
-      - name: Add Agda to PATH
+      - name: Restore and install Agda from Nixpkgs
         if: matrix.toolchain == 'agda'
-        run: echo "$HOME/.cabal/bin" >> "$GITHUB_PATH"
+        run: |
+          nix profile add \
+            "github:NixOS/nixpkgs/${{ matrix.compiler-ref }}#agda"
+          "$HOME/.nix-profile/bin/agda" --version
+          echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
 
       - name: Restore and install Mikan through Cachix
         if: matrix.toolchain == 'mikan'
         run: |
-          nix profile add "$GITHUB_WORKSPACE/compiler"
+          nix profile add \
+            "git+https://codeberg.org/1lab/mikan.git?rev=${{ matrix.compiler-ref }}"
           "$HOME/.nix-profile/bin/mikan" --version
           echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/agda.yaml
+++ b/.github/workflows/agda.yaml
@@ -2,7 +2,6 @@ name: Agda and Mikan
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -99,14 +98,12 @@ jobs:
         if: matrix.toolchain == 'agda'
         run: echo "$HOME/.cabal/bin" >> "$GITHUB_PATH"
 
-      - name: Restore or build Mikan through Cachix
+      - name: Restore and install Mikan through Cachix
         if: matrix.toolchain == 'mikan'
         run: |
-          nix build \
-            --accept-flake-config \
-            --out-link "$GITHUB_WORKSPACE/mikan-result" \
-            "$GITHUB_WORKSPACE/compiler"
-          echo "$GITHUB_WORKSPACE/mikan-result/bin" >> "$GITHUB_PATH"
+          nix profile add "$GITHUB_WORKSPACE/compiler"
+          "$HOME/.nix-profile/bin/mikan" --version
+          echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
 
       - name: Check out the matching Cubical library
         shell: bash

--- a/.github/workflows/agda.yaml
+++ b/.github/workflows/agda.yaml
@@ -86,15 +86,11 @@ jobs:
         if: matrix.toolchain == 'mikan'
         run: sed -i '/^flags:/d' calf/calf.agda-lib
 
-      - name: Restore compiler interface cache
+      - name: Restore Cubical interface cache
         uses: actions/cache@v4
         with:
-          path: |
-            calf/_build
-            cubical/_build
-          key: interfaces-${{ runner.os }}-${{ runner.arch }}-${{ matrix.toolchain }}-${{ matrix.compiler-ref }}-${{ matrix.cubical-ref }}-${{ hashFiles('calf/**/*.agda', 'calf/**/*.agda-lib') }}
-          restore-keys: |
-            interfaces-${{ runner.os }}-${{ runner.arch }}-${{ matrix.toolchain }}-${{ matrix.compiler-ref }}-${{ matrix.cubical-ref }}-
+          path: cubical/_build
+          key: cubical-interfaces-${{ runner.os }}-${{ runner.arch }}-${{ matrix.toolchain }}-${{ matrix.compiler-ref }}-${{ matrix.cubical-ref }}
 
       - name: Show compiler version
         run: ${{ matrix.command }} --version

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,52 +4,98 @@ on:
   push:
     branches:
       - main
+  pull_request:
   release:
     types:
       - published
   workflow_dispatch:
     inputs:
       ref:
-        description: main, or a release tag such as v1.0.0
+        description: Source to publish; main becomes /current/
         required: true
         default: main
 
 permissions:
   contents: read
 
-# Every deployment reads and updates the same gh-pages branch. Queue them so
-# two releases cannot overwrite one another's version directory.
+# Every run updates the same versioned site, so serialize complete runs. The
+# version builds inside each run still execute concurrently as a matrix.
 concurrency:
   group: calf-github-pages
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build documentation
+  prepare:
+    name: Select documentation versions
     runs-on: ubuntu-latest
-    timeout-minutes: 120
     permissions:
-      contents: write
+      contents: read
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
 
     steps:
-      - name: Select source and destination
-        id: version
+      - name: Check out documentation configuration
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.sha || github.event.repository.default_branch }}
+          path: workflow-config
+
+      - name: Select versions to build
+        id: versions
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           REQUESTED_REF: ${{ inputs.ref }}
         run: |
+          manifest="$GITHUB_WORKSPACE/workflow-config/.github/docs-toolchains.json"
+
           case "$EVENT_NAME" in
+            pull_request)
+              releases='[]'
+              page=1
+              while true; do
+                response=$(curl --fail-with-body --silent --show-error \
+                  --header "Authorization: Bearer $GH_TOKEN" \
+                  --header 'Accept: application/vnd.github+json' \
+                  --header 'X-GitHub-Api-Version: 2026-03-10' \
+                  "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases?per_page=100&page=$page")
+                releases=$(jq --compact-output \
+                  --argjson previous "$releases" \
+                  '$previous + .' <<< "$response")
+
+                if (( $(jq 'length' <<< "$response") < 100 )); then
+                  break
+                fi
+                ((page += 1))
+              done
+
+              targets=$(jq --compact-output '
+                ["current"] + [
+                  .[]
+                  | select(.draft == false)
+                  | .tag_name
+                  | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+([.-][0-9A-Za-z.-]+)?$"))
+                ]
+              ' <<< "$releases")
+              ;;
             push)
-              source_ref="$GITHUB_SHA"
-              destination=current
+              targets='["current"]'
               ;;
             release)
-              source_ref="$RELEASE_TAG"
+              targets=$(jq --compact-output --null-input \
+                --arg release "$RELEASE_TAG" \
+                '["current", $release]')
               ;;
             workflow_dispatch)
-              source_ref="$REQUESTED_REF"
+              if [[ "$REQUESTED_REF" == main ]]; then
+                targets='["current"]'
+              else
+                targets=$(jq --compact-output --null-input \
+                  --arg release "$REQUESTED_REF" \
+                  '["current", $release]')
+              fi
               ;;
             *)
               echo "Unsupported event: $EVENT_NAME" >&2
@@ -57,61 +103,57 @@ jobs:
               ;;
           esac
 
-          if [[ -z "${destination:-}" ]]; then
-            if [[ "$source_ref" == main ]]; then
-              destination=current
-            elif [[ "$source_ref" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
-              destination="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-            elif [[ "$source_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.-]+$ ]]; then
-              destination="$source_ref"
+          matrix=$(jq --compact-output \
+            --argjson targets "$targets" '
+              . as $toolchains
+              | ([$targets[] | select($toolchains[.] == null)] | first) as $missing
+              | if $missing != null then
+                  error("No toolchain configured for " + $missing)
+                else
+                  {include: [
+                    $targets[] as $target
+                    | {target: $target} + $toolchains[$target]
+                  ]}
+                end
+            ' "$manifest")
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build documentation (${{ matrix.target }})
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+
+    steps:
+      - name: Select source
+        id: version
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MATRIX_TARGET: ${{ matrix.target }}
+        run: |
+          if [[ "$MATRIX_TARGET" == current ]]; then
+            if [[ "$EVENT_NAME" == push || "$EVENT_NAME" == pull_request ]]; then
+              source_ref="$GITHUB_SHA"
             else
-              echo "Expected main or a semantic-version tag, got: $source_ref" >&2
-              exit 1
+              source_ref=main
             fi
+          else
+            source_ref="$MATRIX_TARGET"
           fi
 
           echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
-          echo "destination=$destination" >> "$GITHUB_OUTPUT"
 
       - name: Check out Calf
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.version.outputs.source_ref }}
           path: calf
-
-      - name: Select the matching Agda and library
-        id: toolchain
-        shell: bash
-        run: |
-          dependency=$(sed -n 's/^depend:[[:space:]]*//p' calf/calf.agda-lib)
-
-          case "$dependency" in
-            standard-library-1.7)
-              echo "agda_version=2.6.2.2" >> "$GITHUB_OUTPUT"
-              echo "nixpkgs_ref=ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b" >> "$GITHUB_OUTPUT"
-              echo "dependency_repository=agda/agda-stdlib" >> "$GITHUB_OUTPUT"
-              echo "dependency_ref=v1.7" >> "$GITHUB_OUTPUT"
-              echo "dependency_library=standard-library.agda-lib" >> "$GITHUB_OUTPUT"
-              ;;
-            standard-library)
-              echo "agda_version=2.6.3" >> "$GITHUB_OUTPUT"
-              echo "nixpkgs_ref=70bdadeb94ffc8806c0570eb5c2695ad29f0e421" >> "$GITHUB_OUTPUT"
-              echo "dependency_repository=agda/agda-stdlib" >> "$GITHUB_OUTPUT"
-              echo "dependency_ref=fc473ec905ab1a11a16718a7e8b628f1ab7eb435" >> "$GITHUB_OUTPUT"
-              echo "dependency_library=standard-library.agda-lib" >> "$GITHUB_OUTPUT"
-              ;;
-            cubical-0.9)
-              echo "agda_version=2.8.0" >> "$GITHUB_OUTPUT"
-              echo "nixpkgs_ref=d351d0653aeb7877273920cd3e823994e7579b0b" >> "$GITHUB_OUTPUT"
-              echo "dependency_repository=agda/cubical" >> "$GITHUB_OUTPUT"
-              echo "dependency_ref=b150186d2544e7efeddd31e5d14a8b9ecbb100f7" >> "$GITHUB_OUTPUT"
-              echo "dependency_library=cubical.agda-lib" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "Unsupported dependency in calf.agda-lib: $dependency" >&2
-              exit 1
-              ;;
-          esac
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -123,28 +165,28 @@ jobs:
       - name: Install the matching Agda from Nixpkgs
         run: |
           nix profile add \
-            "github:NixOS/nixpkgs/${{ steps.toolchain.outputs.nixpkgs_ref }}#agda"
+            "github:NixOS/nixpkgs/${{ matrix.nixpkgs_ref }}#agda"
           "$HOME/.nix-profile/bin/agda" --version
           echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
 
       - name: Check out the matching Agda library
         uses: actions/checkout@v6
         with:
-          repository: ${{ steps.toolchain.outputs.dependency_repository }}
-          ref: ${{ steps.toolchain.outputs.dependency_ref }}
+          repository: ${{ matrix.dependency_repository }}
+          ref: ${{ matrix.dependency_ref }}
           path: dependency
 
       - name: Restore dependency interface cache
         uses: actions/cache@v4
         with:
           path: dependency/_build
-          key: docs-dependency-${{ runner.os }}-${{ runner.arch }}-agda-${{ steps.toolchain.outputs.agda_version }}-${{ steps.toolchain.outputs.dependency_ref }}
+          key: docs-dependency-${{ runner.os }}-${{ runner.arch }}-agda-${{ matrix.agda_version }}-${{ matrix.dependency_ref }}
 
       - name: Register the Agda library
         shell: bash
         run: |
           printf '%s\n' \
-            "$GITHUB_WORKSPACE/dependency/${{ steps.toolchain.outputs.dependency_library }}" \
+            "$GITHUB_WORKSPACE/dependency/${{ matrix.dependency_library }}" \
             > "$GITHUB_WORKSPACE/libraries"
 
       - name: Generate a complete index when the release has none
@@ -169,16 +211,36 @@ jobs:
             src/index.agda
           cp Agda.css docs/Agda.css
 
+      - name: Upload generated documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: calf-documentation-${{ matrix.target }}
+          path: calf/docs
+
+  publish:
+    name: Save complete versioned site
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
       - name: Check out the published site
         uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: site
 
-      - name: Add this version to the site
+      - name: Download generated documentation
+        uses: actions/download-artifact@v4
+        with:
+          pattern: calf-documentation-*
+          path: built-docs
+          merge-multiple: false
+
+      - name: Add the generated versions to the site
         shell: bash
-        env:
-          DESTINATION: ${{ steps.version.outputs.destination }}
         run: |
           # Before this workflow, Decalf v2.0 was published directly at the
           # site root. Preserve it during the one-time layout migration.
@@ -190,9 +252,35 @@ jobs:
               -exec mv -t site/v2.0 -- {} +
           fi
 
-          rm -rf "site/$DESTINATION"
-          mkdir -p "site/$DESTINATION"
-          cp -a calf/docs/. "site/$DESTINATION/"
+          mapfile -t artifacts < <(
+            find built-docs -mindepth 1 -maxdepth 1 -type d \
+              -name 'calf-documentation-*' \
+              -print \
+              | LC_ALL=C sort -V
+          )
+          if (( ${#artifacts[@]} == 0 )); then
+            echo 'No documentation artifacts were downloaded.' >&2
+            exit 1
+          fi
+
+          for artifact in "${artifacts[@]}"; do
+            artifact_name="${artifact##*/}"
+            target="${artifact_name#calf-documentation-}"
+            if [[ "$target" == current ]]; then
+              destination=current
+            elif [[ "$target" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+              destination="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            elif [[ "$target" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.-]+$ ]]; then
+              destination="$target"
+            else
+              echo "Unsafe documentation target: $target" >&2
+              exit 1
+            fi
+
+            rm -rf "site/$destination"
+            mkdir -p "site/$destination"
+            cp -a "$artifact/." "site/$destination/"
+          done
 
           # The previous site lived at the root. Versioned docs are directories,
           # so remove only those old root-level generated files.
@@ -231,16 +319,14 @@ jobs:
 
       - name: Save the complete site on gh-pages
         shell: bash
-        env:
-          DESTINATION: ${{ steps.version.outputs.destination }}
         run: |
           git -C site config user.name github-actions[bot]
           git -C site config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git -C site add -A
           if git -C site diff --cached --quiet; then
-            echo "The $DESTINATION documentation is already up to date."
+            echo 'The versioned documentation is already up to date.'
           else
-            git -C site commit -m "Deploy Calf documentation to $DESTINATION"
+            git -C site commit -m 'Deploy versioned Calf documentation'
             git -C site push origin HEAD:gh-pages
           fi
 
@@ -251,7 +337,7 @@ jobs:
 
   deploy:
     name: Deploy GitHub Pages
-    needs: build
+    needs: publish
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -209,6 +209,7 @@ jobs:
             --html \
             --html-dir=docs \
             src/index.agda
+          rm -f docs/Agda.css
           cp Agda.css docs/Agda.css
 
       - name: Upload generated documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -243,16 +243,6 @@ jobs:
       - name: Add the generated versions to the site
         shell: bash
         run: |
-          # Before this workflow, Decalf v2.0 was published directly at the
-          # site root. Preserve it during the one-time layout migration.
-          if [[ ! -d site/v2.0 && -f site/Calf.CBPV.html ]]; then
-            mkdir -p site/v2.0
-            find site -maxdepth 1 -type f \
-              ! -name CNAME \
-              ! -name .nojekyll \
-              -exec mv -t site/v2.0 -- {} +
-          fi
-
           mapfile -t artifacts < <(
             find built-docs -mindepth 1 -maxdepth 1 -type d \
               -name 'calf-documentation-*' \
@@ -330,25 +320,3 @@ jobs:
             git -C site commit -m 'Deploy versioned Calf documentation'
             git -C site push origin HEAD:gh-pages
           fi
-
-      - name: Upload the complete site
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: site
-
-  deploy:
-    name: Deploy GitHub Pages
-    needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,22 +4,19 @@ on:
   push:
     branches:
       - main
-  pull_request:
   release:
     types:
       - published
   workflow_dispatch:
     inputs:
-      ref:
-        description: Source to publish; main becomes /current/
+      version:
+        description: Release tag to publish, such as v2.0.0
         required: true
-        default: main
 
 permissions:
   contents: read
 
-# Every run updates the same versioned site, so serialize complete runs. The
-# version builds inside each run still execute concurrently as a matrix.
+# Every run updates the same versioned site, so serialize complete runs.
 concurrency:
   group: calf-github-pages
   cancel-in-progress: false
@@ -37,7 +34,7 @@ jobs:
       - name: Check out documentation configuration
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.sha || github.event.repository.default_branch }}
+          ref: ${{ github.event.repository.default_branch }}
           path: workflow-config
 
       - name: Select versions to build
@@ -45,57 +42,32 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
-          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          REQUESTED_REF: ${{ inputs.ref }}
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           manifest="$GITHUB_WORKSPACE/workflow-config/.github/docs-toolchains.json"
 
           case "$EVENT_NAME" in
-            pull_request)
-              releases='[]'
-              page=1
-              while true; do
-                response=$(curl --fail-with-body --silent --show-error \
-                  --header "Authorization: Bearer $GH_TOKEN" \
-                  --header 'Accept: application/vnd.github+json' \
-                  --header 'X-GitHub-Api-Version: 2026-03-10' \
-                  "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases?per_page=100&page=$page")
-                releases=$(jq --compact-output \
-                  --argjson previous "$releases" \
-                  '$previous + .' <<< "$response")
-
-                if (( $(jq 'length' <<< "$response") < 100 )); then
-                  break
-                fi
-                ((page += 1))
-              done
-
-              targets=$(jq --compact-output '
-                ["current"] + [
-                  .[]
-                  | select(.draft == false)
-                  | .tag_name
-                  | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+([.-][0-9A-Za-z.-]+)?$"))
-                ]
-              ' <<< "$releases")
-              ;;
             push)
               targets='["current"]'
               ;;
             release)
+              if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+                echo "Expected a semantic-version release tag, got: $RELEASE_TAG" >&2
+                exit 1
+              fi
               targets=$(jq --compact-output --null-input \
                 --arg release "$RELEASE_TAG" \
-                '["current", $release]')
+                '[$release]')
               ;;
             workflow_dispatch)
-              if [[ "$REQUESTED_REF" == main ]]; then
-                targets='["current"]'
-              else
-                targets=$(jq --compact-output --null-input \
-                  --arg release "$REQUESTED_REF" \
-                  '["current", $release]')
+              if [[ ! "$REQUESTED_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+                echo "Expected a semantic-version release tag, got: $REQUESTED_VERSION" >&2
+                exit 1
               fi
+              targets=$(jq --compact-output --null-input \
+                --arg release "$REQUESTED_VERSION" \
+                '[$release]')
               ;;
             *)
               echo "Unsupported event: $EVENT_NAME" >&2
@@ -134,15 +106,10 @@ jobs:
         id: version
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
           MATRIX_TARGET: ${{ matrix.target }}
         run: |
           if [[ "$MATRIX_TARGET" == current ]]; then
-            if [[ "$EVENT_NAME" == push || "$EVENT_NAME" == pull_request ]]; then
-              source_ref="$GITHUB_SHA"
-            else
-              source_ref=main
-            fi
+            source_ref="$GITHUB_SHA"
           else
             source_ref="$MATRIX_TARGET"
           fi

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,267 @@
+name: Publish versioned documentation
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: main, or a release tag such as v1.0.0
+        required: true
+        default: main
+
+permissions:
+  contents: read
+
+# Every deployment reads and updates the same gh-pages branch. Queue them so
+# two releases cannot overwrite one another's version directory.
+concurrency:
+  group: calf-github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: write
+
+    steps:
+      - name: Select source and destination
+        id: version
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REQUESTED_REF: ${{ inputs.ref }}
+        run: |
+          case "$EVENT_NAME" in
+            push)
+              source_ref="$GITHUB_SHA"
+              destination=current
+              ;;
+            release)
+              source_ref="$RELEASE_TAG"
+              ;;
+            workflow_dispatch)
+              source_ref="$REQUESTED_REF"
+              ;;
+            *)
+              echo "Unsupported event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ -z "${destination:-}" ]]; then
+            if [[ "$source_ref" == main ]]; then
+              destination=current
+            elif [[ "$source_ref" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+              destination="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            elif [[ "$source_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.-]+$ ]]; then
+              destination="$source_ref"
+            else
+              echo "Expected main or a semantic-version tag, got: $source_ref" >&2
+              exit 1
+            fi
+          fi
+
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
+          echo "destination=$destination" >> "$GITHUB_OUTPUT"
+
+      - name: Check out Calf
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.version.outputs.source_ref }}
+          path: calf
+
+      - name: Select the matching Agda and library
+        id: toolchain
+        shell: bash
+        run: |
+          dependency=$(sed -n 's/^depend:[[:space:]]*//p' calf/calf.agda-lib)
+
+          case "$dependency" in
+            standard-library-1.7)
+              echo "agda_version=2.6.2.2" >> "$GITHUB_OUTPUT"
+              echo "nixpkgs_ref=ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b" >> "$GITHUB_OUTPUT"
+              echo "dependency_repository=agda/agda-stdlib" >> "$GITHUB_OUTPUT"
+              echo "dependency_ref=v1.7" >> "$GITHUB_OUTPUT"
+              echo "dependency_library=standard-library.agda-lib" >> "$GITHUB_OUTPUT"
+              ;;
+            standard-library)
+              echo "agda_version=2.6.3" >> "$GITHUB_OUTPUT"
+              echo "nixpkgs_ref=70bdadeb94ffc8806c0570eb5c2695ad29f0e421" >> "$GITHUB_OUTPUT"
+              echo "dependency_repository=agda/agda-stdlib" >> "$GITHUB_OUTPUT"
+              echo "dependency_ref=fc473ec905ab1a11a16718a7e8b628f1ab7eb435" >> "$GITHUB_OUTPUT"
+              echo "dependency_library=standard-library.agda-lib" >> "$GITHUB_OUTPUT"
+              ;;
+            cubical-0.9)
+              echo "agda_version=2.8.0" >> "$GITHUB_OUTPUT"
+              echo "nixpkgs_ref=d351d0653aeb7877273920cd3e823994e7579b0b" >> "$GITHUB_OUTPUT"
+              echo "dependency_repository=agda/cubical" >> "$GITHUB_OUTPUT"
+              echo "dependency_ref=b150186d2544e7efeddd31e5d14a8b9ecbb100f7" >> "$GITHUB_OUTPUT"
+              echo "dependency_library=cubical.agda-lib" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unsupported dependency in calf.agda-lib: $dependency" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            cores = 4
+            max-jobs = 1
+
+      - name: Install the matching Agda from Nixpkgs
+        run: |
+          nix profile add \
+            "github:NixOS/nixpkgs/${{ steps.toolchain.outputs.nixpkgs_ref }}#agda"
+          "$HOME/.nix-profile/bin/agda" --version
+          echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
+
+      - name: Check out the matching Agda library
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ steps.toolchain.outputs.dependency_repository }}
+          ref: ${{ steps.toolchain.outputs.dependency_ref }}
+          path: dependency
+
+      - name: Restore dependency interface cache
+        uses: actions/cache@v4
+        with:
+          path: dependency/_build
+          key: docs-dependency-${{ runner.os }}-${{ runner.arch }}-agda-${{ steps.toolchain.outputs.agda_version }}-${{ steps.toolchain.outputs.dependency_ref }}
+
+      - name: Register the Agda library
+        shell: bash
+        run: |
+          printf '%s\n' \
+            "$GITHUB_WORKSPACE/dependency/${{ steps.toolchain.outputs.dependency_library }}" \
+            > "$GITHUB_WORKSPACE/libraries"
+
+      - name: Generate a complete index when the release has none
+        working-directory: calf
+        shell: bash
+        run: |
+          if [[ ! -f src/index.agda ]]; then
+            printf 'module index where\n\n' > src/index.agda
+            find src -type f -name '*.agda' ! -path 'src/index.agda' -print \
+              | sed -e 's#^src/##' -e 's#\.agda$##' -e 's#/#.#g' \
+              | LC_ALL=C sort \
+              | sed 's/^/import /' >> src/index.agda
+          fi
+
+      - name: Build HTML
+        working-directory: calf
+        run: |
+          agda \
+            --library-file="$GITHUB_WORKSPACE/libraries" \
+            --html \
+            --html-dir=docs \
+            src/index.agda
+          cp Agda.css docs/Agda.css
+
+      - name: Check out the published site
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: site
+
+      - name: Add this version to the site
+        shell: bash
+        env:
+          DESTINATION: ${{ steps.version.outputs.destination }}
+        run: |
+          # Before this workflow, Decalf v2.0 was published directly at the
+          # site root. Preserve it during the one-time layout migration.
+          if [[ ! -d site/v2.0 && -f site/Calf.CBPV.html ]]; then
+            mkdir -p site/v2.0
+            find site -maxdepth 1 -type f \
+              ! -name CNAME \
+              ! -name .nojekyll \
+              -exec mv -t site/v2.0 -- {} +
+          fi
+
+          rm -rf "site/$DESTINATION"
+          mkdir -p "site/$DESTINATION"
+          cp -a calf/docs/. "site/$DESTINATION/"
+
+          # The previous site lived at the root. Versioned docs are directories,
+          # so remove only those old root-level generated files.
+          find site -maxdepth 1 -type f \
+            ! -name CNAME \
+            ! -name .nojekyll \
+            -delete
+          touch site/.nojekyll
+
+          {
+            printf '%s\n' \
+              '<!doctype html>' \
+              '<html lang="en">' \
+              '<head>' \
+              '  <meta charset="utf-8">' \
+              '  <meta name="viewport" content="width=device-width, initial-scale=1">' \
+              '  <title>Calf documentation</title>' \
+              '</head>' \
+              '<body>' \
+              '  <h1>Calf documentation</h1>' \
+              '  <ul>'
+
+            find site -mindepth 1 -maxdepth 1 -type d \
+              \( -name current -o -name 'v*' \) \
+              -printf '%f\n' \
+              | LC_ALL=C sort -V \
+              | while IFS= read -r version; do
+                  printf '    <li><a href="./%s/">%s</a></li>\n' "$version" "$version"
+                done
+
+            printf '%s\n' \
+              '  </ul>' \
+              '</body>' \
+              '</html>'
+          } > site/index.html
+
+      - name: Save the complete site on gh-pages
+        shell: bash
+        env:
+          DESTINATION: ${{ steps.version.outputs.destination }}
+        run: |
+          git -C site config user.name github-actions[bot]
+          git -C site config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git -C site add -A
+          if git -C site diff --cached --quiet; then
+            echo "The $DESTINATION documentation is already up to date."
+          else
+            git -C site commit -m "Deploy Calf documentation to $DESTINATION"
+            git -C site push origin HEAD:gh-pages
+          fi
+
+      - name: Upload the complete site
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    name: Deploy GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/calf.agda-lib
+++ b/calf.agda-lib
@@ -1,4 +1,4 @@
 name: calf
-depend: standard-library cubical-0.9
+depend: cubical-0.9
 include: src
 flags: --guardedness --cubical

--- a/src/1Lab/Type/Pi.agda
+++ b/src/1Lab/Type/Pi.agda
@@ -1,11 +1,11 @@
-module 1Lab.Set.Pi where
+module 1Lab.Type.Pi where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.CartesianKanOps
 
--- The following two proofs are imported from the 1Lab: https://1lab.dev/1Lab.Set.Pi.html
+-- The following two proofs are imported from the 1Lab: https://1lab.dev/1Lab.Type.Pi.html
 funext-dep
-  : ∀ {A : I → Set} {B : (i : I) → A i → Set} {f g}
+  : ∀ {A : I → Type} {B : (i : I) → A i → Type} {f g}
   → ( ∀ {x₀ x₁} (p : PathP A x₀ x₁)
     → PathP (λ i → B i (p i)) (f x₀) (g x₁) )
   → PathP (λ i → (x : A i) → B i x) f g
@@ -14,7 +14,7 @@ funext-dep {A = A} {B} h i x =
     (h (λ j → coei→j A i j x) i)
 
 funext-dep-i0
-  : ∀ {A : I → Set} {B : (i : I) → A i → Set} {f g}
+  : ∀ {A : I → Type} {B : (i : I) → A i → Type} {f g}
   → ( ∀ (x : A i0)
     → PathP (λ i → B i (coe0→i A i x)) (f x) (g (coe0→1 A x)))
   → PathP (λ i → (x : A i) → B i x) f g

--- a/src/Calf/Computation.agda
+++ b/src/Calf/Computation.agda
@@ -135,11 +135,19 @@ opaque
   : Iso (A ⊸ B)
       (Σ[ h ∈ (U A → U B) ]
         ((c : ℂ) (a : U A) → h (A .charge c a) ≡ B .charge c (h a)))
-⊸-Σ-Iso .Iso.fun f = f .U , f .charge
-⊸-Σ-Iso .Iso.inv (h , ch) .U = h
-⊸-Σ-Iso .Iso.inv (h , ch) .charge = ch
-⊸-Σ-Iso .Iso.rightInv _ = refl
-⊸-Σ-Iso .Iso.leftInv _ = refl
+⊸-Σ-Iso = iso to from (λ _ → refl) (λ _ → refl)
+  where
+    to : (A ⊸ B) →
+      (Σ[ h ∈ (U A → U B) ]
+        ((c : ℂ) (a : U A) → h (A .charge c a) ≡ B .charge c (h a)))
+    to f = f .U , f .charge
+
+    from :
+      (Σ[ h ∈ (U A → U B) ]
+        ((c : ℂ) (a : U A) → h (A .charge c a) ≡ B .charge c (h a)))
+      → (A ⊸ B)
+    from (h , ch) .U = h
+    from (h , ch) .charge = ch
 
 opaque
   isSet⊸ : isSet (A ⊸ B)

--- a/src/Calf/Core/Cost.agda
+++ b/src/Calf/Core/Cost.agda
@@ -8,7 +8,17 @@ open import Cubical.Data.Nat.Literals public
 import Cubical.Data.Nat.Properties as Nat
 
 module _ {A : Type} where
-  open import Algebra.Definitions {A = A} _≡_ public
+  LeftIdentity : A → (A → A → A) → Type
+  LeftIdentity e _∙_ = ∀ x → e ∙ x ≡ x
+
+  RightIdentity : A → (A → A → A) → Type
+  RightIdentity e _∙_ = ∀ x → x ∙ e ≡ x
+
+  Associative : (A → A → A) → Type
+  Associative _∙_ = ∀ x y z → (x ∙ y) ∙ z ≡ x ∙ (y ∙ z)
+
+  Commutative : (A → A → A) → Type
+  Commutative _∙_ = ∀ x y → x ∙ y ≡ y ∙ x
 
 `_ = fromNat
 

--- a/src/Calf/Solver/Nat.agda
+++ b/src/Calf/Solver/Nat.agda
@@ -2,6 +2,7 @@
 module Calf.Solver.Nat where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function using (case_of_)
 open import Cubical.Data.Bool using (Bool; true; false; if_then_else_; _and_)
 open import Cubical.Data.Maybe using (Maybe; just; nothing)
 open import Cubical.Data.List using (_++_)
@@ -19,10 +20,16 @@ open import Cubical.Tactics.NatSolver.Solver using (module EqualityToNormalform)
 
 open import Agda.Builtin.List using (List; []; _∷_)
 open import Agda.Builtin.Nat using () renaming (_==_ to _=ℕ_)
-open import Agda.Builtin.Reflection hiding (Type)
+open import Agda.Builtin.Reflection using
+  ( Name; Term; Arg; Literal; TC
+  ; var; con; def; lit; meta
+  ; nat; name
+  ; primQNameEquality; primMetaEquality
+  ; normalise; returnTC; typeError; strErr; termErr
+  ; inferType; checkType; unify
+  )
 open import Agda.Builtin.String using (String)
 open import Agda.Builtin.Unit using (⊤)
-open import Function using (case_of_)
 
 open EqualityToNormalform renaming (solve to natSolve)
 open import Calf.Solver.Nat.Arithmetic public
@@ -59,7 +66,7 @@ private
 
   visibleTerms : List (Arg Term) → List Term
   visibleTerms [] = []
-  visibleTerms (arg (arg-info visible _) t ∷ args) = t ∷ visibleTerms args
+  visibleTerms (varg t ∷ args) = t ∷ visibleTerms args
   visibleTerms (_ ∷ args) = visibleTerms args
 
   visible2 : List (Arg Term) → Maybe (Term × Term)
@@ -128,14 +135,14 @@ private
 
     argListShapeEq : List (Arg Term) → List (Arg Term) → Bool
     argListShapeEq [] [] = true
-    argListShapeEq [] (arg (arg-info visible _) _ ∷ _) = false
+    argListShapeEq [] (varg _ ∷ _) = false
     argListShapeEq [] (_ ∷ args′) = argListShapeEq [] args′
-    argListShapeEq (arg (arg-info visible _) _ ∷ _) [] = false
+    argListShapeEq (varg _ ∷ _) [] = false
     argListShapeEq (_ ∷ args) [] = argListShapeEq args []
-    argListShapeEq (arg (arg-info visible _) t ∷ args)
-                   (arg (arg-info visible _) u ∷ args′) =
+    argListShapeEq (varg t ∷ args)
+                   (varg u ∷ args′) =
       termShapeEq t u and argListShapeEq args args′
-    argListShapeEq (a@(arg (arg-info visible _) _) ∷ args) (_ ∷ args′) =
+    argListShapeEq (a@(varg _) ∷ args) (_ ∷ args′) =
       argListShapeEq (a ∷ args) args′
     argListShapeEq (_ ∷ args) args′ = argListShapeEq args args′
 

--- a/src/Calf/Value/Closed.agda
+++ b/src/Calf/Value/Closed.agda
@@ -6,7 +6,7 @@ open import Calf.Value.Open as ◯ using (◯)
 open import Calf.Value.Sigma
 open import Calf.Value.Unit
 
-open import 1Lab.Set.Pi
+open import 1Lab.Type.Pi
 open import Cubical.Foundations.CartesianKanOps
 open import Cubical.Foundations.Path using (compPathlEquiv; compPathrEquiv)
 open import Cubical.Foundations.Univalence using (hPropExt)

--- a/src/Calf/Value/List.agda
+++ b/src/Calf/Value/List.agda
@@ -25,9 +25,12 @@ isSetList {X} isSetX = subst isSet (ua ΣVec≃List) (isSetΣ isSetℕ isSetVec)
     isSetVec zero = isSetUnit
     isSetVec (suc n) = isSet× isSetX (isSetVec n)
 
+    fwd′ : (n : ℕ) → Vec n → List X
+    fwd′ zero tt = []
+    fwd′ (suc n) (x , xs) = x ∷ fwd′ n xs
+
     fwd : Σ ℕ Vec → List X
-    fwd (zero , tt) = []
-    fwd (suc n , x , xs) = x ∷ fwd (n , xs)
+    fwd (n , xs) = fwd′ n xs
 
     bwd : List X → Σ ℕ Vec
     bwd [] = 0 , tt
@@ -37,10 +40,13 @@ isSetList {X} isSetX = subst isSet (ua ΣVec≃List) (isSetΣ isSetℕ isSetVec)
     fwd-bwd [] = refl
     fwd-bwd (x ∷ l) = cong (x ∷_) (fwd-bwd l)
 
+    bwd-fwd′ : (n : ℕ) (v : Vec n) → bwd (fwd′ n v) ≡ (n , v)
+    bwd-fwd′ zero tt = refl
+    bwd-fwd′ (suc n) (x , v) i =
+      suc (bwd-fwd′ n v i .fst) , x , bwd-fwd′ n v i .snd
+
     bwd-fwd : retract fwd bwd
-    bwd-fwd (zero , tt) = refl
-    bwd-fwd (suc n , x , v) i .fst = suc (bwd-fwd (n , v) i .fst)
-    bwd-fwd (suc n , x , v) i .snd = x , bwd-fwd (n , v) i .snd
+    bwd-fwd (n , v) = bwd-fwd′ n v
 
     ΣVec≃List : Σ ℕ Vec ≃ List X
     ΣVec≃List .fst = fwd

--- a/src/Examples/Giralf/Inference.agda
+++ b/src/Examples/Giralf/Inference.agda
@@ -13,7 +13,7 @@ open import Calf.Computation.Product
 open import Calf.Giralf
 
 open import Cubical.Data.Nat
-open import Cubical.Data.Nat.Order using (_≤_)
+open import Cubical.Data.Nat.Order using (_≤_; ≤Dec)
 open import Cubical.Data.Vec
 open import Calf.Computation
 
@@ -21,7 +21,6 @@ open import Calf.Solver.Nat using (solveNat0; solveNat)
 
 open import Cubical.Data.Bool hiding (_≤_)
 import Cubical.Data.Nat.Properties as Nat
-open import Cubical.Data.Nat.Order
 open import Cubical.Relation.Nullary
 
 arithmetic-0 : ∀ {l1 q2 : ℕ} → suc q2 ≤ l1 → suc q2 ≤ l1

--- a/src/Examples/Giralf/InsertionSort.agda
+++ b/src/Examples/Giralf/InsertionSort.agda
@@ -16,7 +16,7 @@ open import Calf.Giralf
 open import Cubical.Data.Bool
 open import Cubical.Data.Nat
 import Cubical.Data.Nat.Properties as Nat
-open import Cubical.Data.Nat.Order
+open import Cubical.Data.Nat.Order using (≤Dec)
 open import Cubical.Relation.Nullary
 
 _≤ᵇ_ : ℕ → ℕ → Bool


### PR DESCRIPTION
This PR makes the codebase compatible with Mikan and Cubical Agda. We can keep the upcoming development on Cubical Agda, but compatibility with Mikan is helpful from time to time, especially for performance bottleneck analysis. 

Mikan uses a migrated [cubical](https://codeberg.org/1lab/agda-cubical) library. To run Mikan on this codebase:
```
mikan --no-libraries --no-allow-unsolved-metas \
  -i src \
  -i [PATH_TO_MIGRATED_CUBICAL_LIBRARY] \
  src/Calf.agda
```

There's no good way to run this interactively unless you are willing to temporarily change your `calf.agda-lib` file, because Mikan no longer supports `--cubical` flag. If you do want to change `calf.agda-lib`, here's how:
```
name: calf
include: src [PATH_TO_MIGRATED_CUBICAL_LIBRARY]
```

On VS Code, one can add Mikan to the list of executable, and run `C-x C-s` to switch between Mikan and Cubical Agda.

Here's a performance analysis on the current codebase:
| | Cubical Agda | Mikan |
|---|---:|---:|
| Wall time | 84.82 s | 48.63 s |
